### PR TITLE
Adding Golang support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# A Docker base image for Ruby, Python, Node.js and Meteor web apps
+# A Docker base image for Ruby, Python, Node.js, Meteor, and Golang web apps
 
 <center><img src="http://blog.phusion.nl/wp-content/uploads/2012/07/Passenger_chair_256x256.jpg" width="196" height="196" alt="Phusion Passenger"> <img src="http://blog.phusion.nl/wp-content/uploads/2013/11/docker.png" width="233" height="196" alt="Docker"></center>
 
-Passenger-docker is a [Docker](http://www.docker.io) image meant to serve as a good base for Ruby, Python, Node.js and Meteor web app images. In line with [Phusion Passenger](https://www.phusionpassenger.com/)'s goal, passenger-docker's goal is to make Docker image building for web apps much easier and faster.
+Passenger-docker is a [Docker](http://www.docker.io) image meant to serve as a good base for Ruby, Python, Node.js, Meteor, and Golang web app images. In line with [Phusion Passenger](https://www.phusionpassenger.com/)'s goal, passenger-docker's goal is to make Docker image building for web apps much easier and faster.
 
 Why is this image called "passenger"? It's to represent the ease: you just have to sit back and watch most of the heavy lifting being done for you. Passenger-docker is part of a larger and more ambitious project: to make web app deployment ridiculously simple, to heights never achieved before.
 
@@ -45,6 +45,7 @@ Language support:
    * Ruby is installed through [the Brightbox APT repository](https://launchpad.net/~brightbox/+archive/ruby-ng). We're not using RVM!
  * Python 2.7 and Python 3.0.
  * Node.js 0.10, through [Chris Lea's Node.js PPA](https://launchpad.net/~chris-lea/+archive/node.js/).
+ * Golang 1.2rc5, through [Josh Bussdieker's gvm](https://github.com/moovweb/gvm)
  * A build system, git, and development headers for many popular libraries, so that the most popular Ruby, Python and Node.js native extensions can be compiled without problems.
 
 Web server and application server:
@@ -125,6 +126,8 @@ So put the following in your Dockerfile:
     #/build/python.sh
     #   Node.js and Meteor support.
     #/build/nodejs.sh
+    #  Golang support (requires build system and git).
+    #/build/golang.sh
     
     # ...put other build instructions here...
     

--- a/image/golang.sh
+++ b/image/golang.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -e
+source /build/buildconfig
+set -x
+
+$minimal_apt_get_install mercurial bison
+update-ca-certificates --fresh
+bash < <(curl -s https://raw.github.com/moovweb/gvm/master/binscripts/gvm-installer)
+source /root/.gvm/scripts/gvm
+gvm install go1.2rc5
+gvm use go1.2rc5
+gvm pkgset create dev
+
+cat <<EOF >> /root/.bashrc
+gvm use go1.2rc5 >/dev/null
+gvm pkgset use dev >/dev/null
+EOF

--- a/image/install.sh
+++ b/image/install.sh
@@ -18,6 +18,7 @@ if [[ -z "$minimal" ]]; then
 	/build/nodejs.sh
 	/build/memcached.sh
 	/build/redis.sh
+	/build/golang.sh
 fi
 
 /build/finalize.sh


### PR DESCRIPTION
A couple of notes:
- The debian Go package builds are frozen and no longer supported or up to date
  [[source](https://launchpad.net/~gophers/+archive/go)]
- Installing Go with `gvm` instead of building from source was
  preferred because it is faster and much easier for managing different
  versions of Go
- `gvm` is being installed as the root user because it is not necessary
  for the app user to be able to compile a Go application in order to
  run it. It is recommended that any application be built as root and then
  moved to the correct location with the correct permissions so that it
  may be run by the app user.
