### PR TITLE
Installing missing gem1.8 via rubygems package

### DIFF
--- a/image/ruby1.8.sh
+++ b/image/ruby1.8.sh
@@ -3,6 +3,6 @@ set -e
 source /build/buildconfig
 set -x
 
-$minimal_apt_get_install ruby1.8 ruby1.8-dev
+$minimal_apt_get_install ruby1.8 ruby1.8-dev rubygems
 gem1.8 install rake bundler --no-rdoc --no-ri
 /build/ruby-finalize.sh


### PR DESCRIPTION
It looks like neither the `ruby1.8` package nor the `ruby1.8-dev`
package installs `gem1.8`; however, `rubygems` does.
