### PR TITLE
Dockerfile: explicitly expose ports 80 443

### DIFF
--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -6,3 +6,4 @@ RUN mkdir /build
 ADD . /build
 RUN /build/install.sh
 CMD ["/sbin/my_init"]
+EXPOSE 22 80 443


### PR DESCRIPTION
required due to phusion/baseimage-docker#18
