### PR TITLE
Parametrized, cleaned

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,33 +3,52 @@
 ROOT = File.dirname(File.expand_path(__FILE__))
 
 # Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
-VAGRANTFILE_API_VERSION = "2"
+VAGRANTFILE_API_VERSION = '2'
+
+# Default env properties which can be overridden
+# Example overrides:
+#   echo "ENV['PASSENGER_PATH_URI' ] ||= '../../phusion/passenger-docker'   " >> ~/.vagrant.d/Vagrantfile
+#   echo "ENV['BASE_BOX_URL']        ||= 'd\:/dev/vm/vagrant/boxes/phusion/'" >> ~/.vagrant.d/Vagrantfile
+BASE_BOX_URL        = ENV['BASE_BOX_URL'       ] || 'https://oss-binaries.phusionpassenger.com/vagrant/boxes/'
+VAGRANT_BOX_URL     = ENV['VAGRANT_BOX_URL'    ] || BASE_BOX_URL + 'ubuntu-12.04.3-amd64-vbox.box'
+VMWARE_BOX_URL      = ENV['VMWARE_BOX_URL'     ] || BASE_BOX_URL + 'ubuntu-12.04.3-amd64-vmwarefusion.box'
+BASEIMAGE_PATH_URI  = ENV['BASEIMAGE_PATH_URI' ] || '../baseimage-docker'
+PASSENGER_PATH_URI  = ENV['PASSENGER_PATH_URI' ] || '../passenger-docker'
+DOCKERIZER_PATH_URI = ENV['DOCKERIZER_PATH_URI'] || '../dockerizer'
+
+$script = <<SCRIPT
+wget -q -O - https://get.docker.io/gpg | apt-key add -
+echo deb http://get.docker.io/ubuntu docker main > /etc/apt/sources.list.d/docker.list
+apt-get update -qq
+apt-get install -q -y --force-yes lxc-docker
+usermod -a -G docker vagrant
+docker version
+su - vagrant -c 'echo alias d=docker >> ~/.bash_aliases'
+SCRIPT
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.box = "phusion-open-ubuntu-12.04-amd64"
-  config.vm.box_url = "https://oss-binaries.phusionpassenger.com/vagrant/boxes/ubuntu-12.04.3-amd64-vbox.box"
+  config.vm.box = 'phusion-open-ubuntu-12.04-amd64'
+  config.vm.box_url = VAGRANT_BOX_URL
   config.ssh.forward_agent = true
-  if File.directory?("#{ROOT}/../baseimage-docker")
-    config.vm.synced_folder File.expand_path("#{ROOT}/../baseimage-docker"),
-      "/vagrant/baseimage-docker"
+  passenger_path = "#{ROOT}/#{PASSENGER_PATH_URI}"
+  if File.directory?(passenger_path)
+    config.vm.synced_folder File.expand_path(passenger_path), '/vagrant/passenger-docker'
   end
-  if File.directory?("#{ROOT}/../dockerizer")
-    config.vm.synced_folder File.expand_path("#{ROOT}/../dockerizer"),
-      "/vagrant/dockerizer"
+  baseimage_path = "#{ROOT}/#{BASEIMAGE_PATH_URI}"
+  if File.directory?(baseimage_path)
+    config.vm.synced_folder File.expand_path(baseimage_path), '/vagrant/baseimage-docker'
+  end
+  dockerizer_path = "#{ROOT}/#{DOCKERIZER_PATH_URI}"
+  if File.directory?(dockerizer_path)
+    config.vm.synced_folder File.expand_path(dockerizer_path), '/vagrant/dockerizer'
   end
 
   config.vm.provider :vmware_fusion do |f, override|
-    override.vm.box_url = "https://oss-binaries.phusionpassenger.com/vagrant/boxes/ubuntu-12.04.3-amd64-vmwarefusion.box"
-    f.vmx["displayName"] = "passenger-docker"
+    override.vm.box_url = VMWARE_BOX_URL
+    f.vmx['displayName'] = 'passenger-docker'
   end
 
   if Dir.glob("#{File.dirname(__FILE__)}/.vagrant/machines/default/*/id").empty?
-    # Add lxc-docker package
-    pkg_cmd = "wget -q -O - https://get.docker.io/gpg | apt-key add -;" \
-      "echo deb http://get.docker.io/ubuntu docker main > /etc/apt/sources.list.d/docker.list;" \
-      "apt-get update -qq; apt-get install -q -y --force-yes lxc-docker; "
-    # Add vagrant user to the docker group
-    pkg_cmd << "usermod -a -G docker vagrant; "
-    config.vm.provision :shell, :inline => pkg_cmd
+    config.vm.provision :shell, :inline => $script
   end
 end


### PR DESCRIPTION
- Parametrize with examples.
- All synced_folders are included.
- Print docker version 
- Add a d alias to docker 
- Cleanup
- Vagrantfile of passenger is nearly identical to that of baseimage now.  (I got to that when wanting to try passenger.  But already had a vagrant box started from baseimage, there was no need to dup the effort, just reuse the existing single box for all.  Then in end of day, may not need multiple Vagrantfiles.  Passenger is a simple structure/process for managing dockers, but only needing to use baseimage once and have one VM up.)
