### PR TITLE
README: Add apt-get update and upgrade to example

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,14 @@ So put the following in your Dockerfile:
     #FROM phusion/passenger-nodejs:<VERSION>
     #FROM phusion/passenger-customizable:<VERSION>
     
+    # Update installed packages
+    ENV DEBIAN_FRONTEND noninteractive
+    RUN apt-get update
+    # Force dpkg to use default answer in case something
+    # wants to replace a config file
+    RUN apt-get upgrade -y -o DPkg::Options::="--force-confold"
+
+    
     # Set correct environment variables.
     ENV HOME /root
     


### PR DESCRIPTION
The current image includes nginx 1.4.3 which [has at least one security vulnerability](http://nginx.org/en/security_advisories.html).

These commands are necessary to ensure the latest package versions with security fixes are installed.

This change should probably also be applied to the baseimage README.

Something related: I'm not exactly sure how the Ubuntu apt sources work, but when looking at the `apt-get update` output, I missed the `security.ubuntu.com` sources which I usually see when updating an Ubuntu system.
