### PR TITLE
Setting env in nginx: /etc/main.d/*.env not included

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,14 +259,14 @@ For example:
 
 By default Nginx [clears all environment variables](http://nginx.org/en/docs/ngx_core_module.html#env) (except `TZ`) for its child processes (Passenger being one of them). That's why any environment variables you set with `docker run -e`, Docker linking and `/etc/container_environment`, won't reach Nginx.
 
-To preserve these variables, place a file in the directory `/etc/nginx/main.d`. For example when linking a PostgreSQL container or MongoDB container:
+To preserve these variables, place a file ending in `*.conf` in the directory `/etc/nginx/main.d`. For example when linking a PostgreSQL container or MongoDB container:
 
-    # /etc/nginx/main.d/postgres.env:
+    # /etc/nginx/main.d/postgres-env.conf:
     env POSTGRES_PORT_5432_TCP_ADDR;
     env POSTGRES_PORT_5432_TCP_PORT;
     
     # Dockerfile:
-    ADD postgres.env /etc/nginx/main.d/postgres.env
+    ADD postgres-env.conf /etc/nginx/main.d/postgres-env.conf
 
 By default, passenger-docker already contains a config file `/etc/nginx/main.d/default.conf` which preserves the `PATH` environment variable.
 


### PR DESCRIPTION
The [Setting environment variables](https://github.com/phusion/passenger-docker#setting-environment-variables-in-nginx) section in the README tells users to create `*.env` files to transmit environment variables to the nginx child processes like this:

```
# Dockerfile
ADD postgres.env /etc/nginx/main.d/postgres.env
```

However, the current nginx configuration only includes files in `/etc/nginx/main.d` that end in `*.conf`, and won't include those ending in `*.env`.

``` sh
# rgrep main.d /etc/nginx  
/etc/nginx/nginx.conf:include /etc/nginx/main.d/*.conf;
```

This PR updates the README to tell users to inject their environment file as `*-env.conf` so that they are included by nginx, like this:

```
# Dockerfile
ADD postgres-env.conf /etc/nginx/main.d/postgres-env.conf
```
