### PR TITLE
corrected ruby version values in ruby-switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,12 +333,12 @@ Note that the shell script must run the daemon **without letting it daemonize/fo
 The default Ruby (what the `/usr/bin/ruby` command executes) is the latest Ruby version that you've chosen to install. You can use `ruby-switch` to select a different version as default.
 
     # Ruby 1.9.3 (you can ignore the "1.9.1" suffix)
-    RUN ruby-switch --set 1.9.1
+    RUN ruby-switch --set ruby1.9.1
     # Ruby 2.0.0
-    RUN ruby-switch --set 2.0
+    RUN ruby-switch --set ruby2.0
     # Ruby 2.1.0
-    RUN ruby-switch --set 2.1
-
+    RUN ruby-switch --set ruby2.1
+    
 <a name="running_startup_scripts"></a>
 ### Running scripts during container startup
 


### PR DESCRIPTION
Correction for the following error
$ ruby-switch --set 2.0
Invalid interpreter: 2.0

$ ruby-switch --list
   ruby1.9.1
   ruby2.0
   ruby2.1
