### PR TITLE
Added support for JRuby (1.7.18)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,13 +2,21 @@ NAME = phusion/passenger
 VERSION = 0.9.14
 
 .PHONY: all build_all \
-	build_customizable build_ruby19 build_ruby20 build_ruby21 \
+	build_customizable \
+	build_ruby19 build_ruby20 build_ruby21 build_jruby17 \
 	build_nodejs build_full \
 	tag_latest release clean
 
 all: build_all
 
-build_all: build_customizable build_ruby19 build_ruby20 build_ruby21 build_nodejs build_full
+build_all: \
+	build_customizable \
+	build_ruby19 \
+	build_ruby20 \
+	build_ruby21 \
+	build_jruby17 \
+	build_nodejs \
+	build_full
 
 # Docker doesn't support sharing files between different Dockerfiles. -_-
 # So we copy things around.
@@ -38,6 +46,13 @@ build_ruby21:
 	echo final=1 >> ruby21_image/buildconfig
 	docker build -t $(NAME)-ruby21:$(VERSION) --rm ruby21_image
 
+build_jruby17:
+	rm -rf jruby17_image
+	cp -pR image jruby17_image
+	echo jruby17=1 >> jruby17_image/buildconfig
+	echo final=1 >> jruby17_image/buildconfig
+	docker build -t $(NAME)-jruby17:$(VERSION) --rm jruby17_image
+
 build_nodejs:
 	rm -rf nodejs_image
 	cp -pR image nodejs_image
@@ -51,6 +66,7 @@ build_full:
 	echo ruby19=1 >> full_image/buildconfig
 	echo ruby20=1 >> full_image/buildconfig
 	echo ruby21=1 >> full_image/buildconfig
+	echo jruby17=1 >> full_image
 	echo python=1 >> full_image/buildconfig
 	echo nodejs=1 >> full_image/buildconfig
 	echo redis=1 >> full_image/buildconfig
@@ -63,6 +79,7 @@ tag_latest:
 	docker tag $(NAME)-ruby19:$(VERSION) $(NAME)-ruby19:latest
 	docker tag $(NAME)-ruby20:$(VERSION) $(NAME)-ruby20:latest
 	docker tag $(NAME)-ruby21:$(VERSION) $(NAME)-ruby21:latest
+	docker tag $(NAME)-jruby17:$(VERSION) $(NAME)-jruby17:latest
 	docker tag $(NAME)-nodejs:$(VERSION) $(NAME)-nodejs:latest
 	docker tag $(NAME)-full:$(VERSION) $(NAME)-full:latest
 
@@ -71,12 +88,14 @@ release: tag_latest
 	@if ! docker images $(NAME)-ruby19 | awk '{ print $$2 }' | grep -q -F $(VERSION); then echo "$(NAME)-ruby19 version $(VERSION) is not yet built. Please run 'make build'"; false; fi
 	@if ! docker images $(NAME)-ruby20 | awk '{ print $$2 }' | grep -q -F $(VERSION); then echo "$(NAME)-ruby20 version $(VERSION) is not yet built. Please run 'make build'"; false; fi
 	@if ! docker images $(NAME)-ruby21 | awk '{ print $$2 }' | grep -q -F $(VERSION); then echo "$(NAME)-ruby21 version $(VERSION) is not yet built. Please run 'make build'"; false; fi
+	@if ! docker images $(NAME)-jruby17 | awk '{ print $$2 }' | grep -q -F $(VERSION); then echo "$(NAME)-jruby17 version $(VERSION) is not yet built. Please run 'make build'"; false; fi
 	@if ! docker images $(NAME)-nodejs | awk '{ print $$2 }' | grep -q -F $(VERSION); then echo "$(NAME)-nodejs version $(VERSION) is not yet built. Please run 'make build'"; false; fi
 	@if ! docker images $(NAME)-full | awk '{ print $$2 }' | grep -q -F $(VERSION); then echo "$(NAME)-full version $(VERSION) is not yet built. Please run 'make build'"; false; fi
 	docker push $(NAME)-customizable
 	docker push $(NAME)-ruby19
 	docker push $(NAME)-ruby20
 	docker push $(NAME)-ruby21
+	docker push $(NAME)-jruby17
 	docker push $(NAME)-nodejs
 	docker push $(NAME)-full
 	@echo "*** Don't forget to create a tag. git tag rel-$(VERSION) && git push origin rel-$(VERSION)"
@@ -86,5 +105,6 @@ clean:
 	rm -rf ruby19_image
 	rm -rf ruby20_image
 	rm -rf ruby21_image
+	rm -rf jruby17_image
 	rm -rf nodejs_image
 	rm -rf full_image

--- a/README.md
+++ b/README.md
@@ -159,13 +159,13 @@ So put the following in your Dockerfile:
     #FROM phusion/passenger-ruby21:<VERSION>
     #FROM phusion/passenger-nodejs:<VERSION>
     #FROM phusion/passenger-customizable:<VERSION>
-    
+
     # Set correct environment variables.
     ENV HOME /root
-    
+
     # Use baseimage-docker's init process.
     CMD ["/sbin/my_init"]
-    
+
     # If you're using the 'customizable' variant, you need to explicitly opt-in
     # for features. Uncomment the features you want:
     #
@@ -179,9 +179,9 @@ So put the following in your Dockerfile:
     #RUN /build/python.sh
     #   Node.js and Meteor support.
     #RUN /build/nodejs.sh
-    
+
     # ...put your own build instructions here...
-    
+
     # Clean up APT when done.
     RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
@@ -213,16 +213,16 @@ You can add a virtual host entry (`server` block) by placing a .conf file in the
         listen 80;
         server_name www.webapp.com;
         root /home/app/webapp/public;
-        
+
         # The following deploys your Ruby/Python/Node.js/Meteor app on Passenger.
-        
+
         # Not familiar with Passenger, and used (G)Unicorn/Thin/Puma/pure Node before?
         # Yes, this is all you need to deploy on Passenger! All the reverse proxying,
         # socket setup, process management, etc are all taken care automatically for
         # you! Learn more at https://www.phusionpassenger.com/.
         passenger_enabled on;
         passenger_user app;
-        
+
         # If this is a Ruby app, specify a Ruby version:
         passenger_ruby /usr/bin/ruby2.1;
         # For Ruby 2.0
@@ -230,7 +230,7 @@ You can add a virtual host entry (`server` block) by placing a .conf file in the
         # For Ruby 1.9.3 (you can ignore the "1.9.1" suffix)
         #passenger_ruby /usr/bin/ruby1.9.1;
     }
-    
+
     # Dockerfile:
     ADD webapp.conf /etc/nginx/sites-enabled/webapp.conf
     RUN mkdir /home/app/webapp
@@ -245,10 +245,10 @@ For example:
 
     # /etc/nginx/main.d/secret_key.conf:
     env SECRET_KEY 123456;
-    
+
     # /etc/nginx/conf.d/gzip_max.conf:
     gzip_comp_level 9;
-    
+
     # Dockerfile:
     ADD secret_key.conf /etc/nginx/main.d/secret_key.conf
     ADD gzip_max.conf /etc/nginx/conf.d/gzip_max.conf
@@ -263,7 +263,7 @@ To preserve these variables, place a file ending in `*.conf` in the directory `/
     # /etc/nginx/main.d/postgres-env.conf:
     env POSTGRES_PORT_5432_TCP_ADDR;
     env POSTGRES_PORT_5432_TCP_PORT;
-    
+
     # Dockerfile:
     ADD postgres-env.conf /etc/nginx/main.d/postgres-env.conf
 
@@ -278,7 +278,7 @@ Install and enable Redis:
 
     # Opt-in for Redis if you're using the 'customizable' image.
     #RUN /build/redis.sh
-    
+
     # Enable the Redis service.
     RUN rm -f /etc/service/redis/down
 
@@ -336,7 +336,7 @@ The default Ruby (what the `/usr/bin/ruby` command executes) is the latest Ruby 
     RUN ruby-switch --set ruby2.0
     # Ruby 2.1.0
     RUN ruby-switch --set ruby2.1
-    
+
 <a name="running_startup_scripts"></a>
 ### Running scripts during container startup
 
@@ -500,6 +500,7 @@ Build one of the images:
     make build_ruby19
     make build_ruby20
     make build_ruby21
+    make build_jruby17
     make build_nodejs
     make build_customizable
     make build_full

--- a/image/enable_repos.sh
+++ b/image/enable_repos.sh
@@ -4,11 +4,9 @@ source /build/buildconfig
 set -x
 
 ## Brightbox Ruby 1.9.3, 2.0 and 2.1
-apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C3173AA6
 echo deb http://ppa.launchpad.net/brightbox/ruby-ng/ubuntu trusty main > /etc/apt/sources.list.d/brightbox.list
 
 ## Phusion Passenger
-apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 561F9B9CAC40B2F7
 if [[ "$PASSENGER_ENTERPRISE" ]]; then
 	echo deb https://download:$PASSENGER_ENTERPRISE_DOWNLOAD_TOKEN@www.phusionpassenger.com/enterprise_apt trusty main > /etc/apt/sources.list.d/passenger.list
 else
@@ -16,11 +14,29 @@ else
 fi
 
 ## Chris Lea's Node.js PPA
-apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C7917B12
 echo deb http://ppa.launchpad.net/chris-lea/node.js/ubuntu trusty main > /etc/apt/sources.list.d/nodejs.list
 
 ## Rowan's Redis PPA
-apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 5862E31D
 echo deb http://ppa.launchpad.net/rwky/redis/ubuntu trusty main > /etc/apt/sources.list.d/redis.list
+
+# The recv-keys part takes a bit of time, so it's faster to receive multiple keys at once.
+#
+# Brightbox
+# Phusion Passenger
+# Chris Lea's Node.js PPA
+# Rowan's Redis PPA
+apt-key adv --keyserver keyserver.ubuntu.com --recv-keys \
+C3173AA6 \
+561F9B9CAC40B2F7 \
+C7917B12 \
+5862E31D
+
+## Debian's sid repo, needed for OpenJDK 8.
+apt-key adv --keyserver pgpkeys.mit.edu --recv-keys 8B48AD6246925553
+echo deb http://http.us.debian.org/debian unstable main non-free contrib > /etc/apt/sources.list.d/sid.list
+echo -e "\
+Package: *\n\
+Pin: release o=Debian\n\
+Pin-Priority: -10\n" > /etc/apt/preferences.d/sid
 
 apt-get update

--- a/image/install.sh
+++ b/image/install.sh
@@ -11,6 +11,7 @@ set -x
 if [[ "$ruby19" = 1 ]]; then /build/ruby1.9.sh; fi
 if [[ "$ruby20" = 1 ]]; then /build/ruby2.0.sh; fi
 if [[ "$ruby21" = 1 ]]; then /build/ruby2.1.sh; fi
+if [[ "$jruby17" = 1 ]]; then /build/jruby1.7.sh; fi
 if [[ "$python" = 1 ]]; then /build/python.sh; fi
 if [[ "$nodejs" = 1 ]]; then /build/nodejs.sh; fi
 if [[ "$redis" = 1 ]]; then /build/redis.sh; fi

--- a/image/jruby1.7.sh
+++ b/image/jruby1.7.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+set -e
+source /build/buildconfig
+set -x
+
+apt-get install -y -t sid openjdk-8-jre-headless
+dpkg-reconfigure ca-certificates-java
+
+curl https://s3.amazonaws.com/jruby.org/downloads/1.7.18/jruby-bin-1.7.18.tar.gz -o /tmp/jruby-bin-1.7.18.tar.gz
+cd /usr/local
+tar xzf /tmp/jruby-bin-1.7.18.tar.gz
+
+# For convenience.
+cd /usr/local/jruby-1.7.18/bin
+ln -sf /usr/local/jruby-1.7.18/bin/jruby /usr/bin/ruby
+
+# To keep the image smaller; these are only needed on Windows anyway.
+rm -rf *.bat *.dll *.exe
+
+echo "PATH=\"\$PATH:/usr/local/jruby-1.7.18/bin\"" >> /etc/environment
+source /etc/environment
+
+gem install rake bundler --no-rdoc --no-ri
+
+echo "gem: --no-ri --no-rdoc" > /etc/gemrc
+
+# This part is needed to get Debian dependencies working correctly, so that the nginx-passenger.sh script does not
+# install Ruby 1.9 and/or other YARV Ruby versions (if all we want is JRuby).
+cd /tmp
+mkdir -p jruby-fake/DEBIAN
+cat <<-EOF > jruby-fake/DEBIAN/control
+Source: jruby-fake
+Section: ruby
+Priority: optional
+Maintainer: Unmaintained <noreply@debian.org>
+Build-Depends: debhelper (>= 9~), openjdk-7-jdk (>= 7u71-2.5.3), ant-optional,
+ libasm3-java, libcommons-logging-java, libjarjar-java, libjoda-time-java,
+ junit4, libbsf-java, libjline-java, bnd, libconstantine-java,
+ netbase, libjgrapht0.8-java, libjcodings-java, libbytelist-java, libjffi-java,
+ libjaffl-java, libjruby-joni-java, yydebug, nailgun, libjnr-posix-java,
+ libjnr-netdb-java, libyecht-java (>= 0.0.2-2~), cdbs, maven-repo-helper
+Standards-Version: 3.9.6
+Homepage: http://jruby.org
+Package: jruby-fake
+Version: 1.7.18
+Architecture: all
+Replaces: jruby1.0, jruby1.1, jruby1.2
+Provides: ruby-interpreter, rubygems1.9
+Depends: default-jre | java6-runtime | java-runtime-headless
+Recommends: ri
+Description: 100% pure-Java implementation of Ruby (fake package)
+ JRuby is a 100% pure-Java implementation of the Ruby programming language.
+ .
+ JRuby provides a complete set of core "builtin" classes and syntax
+ for the Ruby language, as well as most of the Ruby Standard
+ Libraries. The standard libraries are mostly Ruby's own complement of
+ ".rb" files, but a few that depend on C language-based extensions have
+ been reimplemented. Some are still missing, but JRuby hopes to
+ implement as many as is feasible.
+ .
+ This is a fake package that does not contain any files; it exists just to
+ satisfy dependencies.
+EOF
+
+dpkg-deb -b jruby-fake .
+dpkg -i jruby-fake_1.7.18_all.deb

--- a/image/jruby1.7.sh
+++ b/image/jruby1.7.sh
@@ -20,7 +20,7 @@ rm -rf *.bat *.dll *.exe
 echo "PATH=\"\$PATH:/usr/local/jruby-1.7.18/bin\"" >> /etc/environment
 source /etc/environment
 
-gem install rake bundler --no-rdoc --no-ri
+gem install rake bundler rack --no-rdoc --no-ri
 
 echo "gem: --no-ri --no-rdoc" > /etc/gemrc
 

--- a/image/nginx-passenger.sh
+++ b/image/nginx-passenger.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -e
 source /build/buildconfig
+source /etc/environment
 set -x
 
 ## Install Phusion Passenger.
@@ -33,4 +34,8 @@ fi
 if [[ -e /usr/bin/ruby1.9.1 ]]; then
 	ruby1.9.1 -S passenger-config build-native-support
 	setuser app ruby1.9.1 -S passenger-config build-native-support
+fi
+if [[ -e /usr/local/jruby-1.7.18/bin/jruby ]]; then
+  jruby -S passenger-config build-native-support
+  setuser app jruby -S passenger-config build-native-support
 fi


### PR DESCRIPTION
This PR adds support for building a JRuby Docker image as well. The version of JRuby in Debian and Ubuntu at the moment is ancient (4 years old), so we have to take a bit more manual steps to download it and so forth.