### PR TITLE
[passenger-customizable] nginx-passenger installing ruby2.2 

### DIFF
--- a/image/finalize.sh
+++ b/image/finalize.sh
@@ -8,6 +8,6 @@ rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 if [[ "$final" = 1 ]]; then
 	rm -rf /pd_build
 else
-	rm -f /pd_build/{install,enable_repos,prepare,pups,nginx-passenger,finalize}.sh
+	rm -f /pd_build/{install,enable_repos,prepare,pups,finalize}.sh
 	rm -f /pd_build/{Dockerfile,insecure_key*}
 fi

--- a/image/install.sh
+++ b/image/install.sh
@@ -18,6 +18,6 @@ if [[ "$redis" = 1 ]]; then /pd_build/redis.sh; fi
 if [[ "$memcached" = 1 ]]; then /pd_build/memcached.sh; fi
 
 # Must be installed after Ruby, so that we don't end up with two Ruby versions.
-/pd_build/nginx-passenger.sh
+command -v ruby >/dev/null 2>&1 && /pd_build/nginx-passenger.sh
 
 /pd_build/finalize.sh


### PR DESCRIPTION
Passenger depends on ruby, since ruby repository is enable it will pull the most recent version available:

``` shell
apt-cache rdepends ruby2.2
ruby2.2
Reverse Depends:
 |passenger
 |passenger-dev
```

Only install nginx and passenger if ruby is installed.
