### PR TITLE
List the correct Python 3 version in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Language support:
    * MRI Ruby is installed through [the Brightbox APT repository](https://launchpad.net/~brightbox/+archive/ruby-ng). We're not using RVM!
    * JRuby is installed from source, but we register an APT entry for it.
    * JRuby uses OpenJDK 8 from [the openjdk-r PPA](https://launchpad.net/~openjdk-r/+archive/ubuntu/ppa).
- * Python 2.7 and Python 3.0.
+ * Python 2.7 and Python 3.4.
  * Node.js 0.12, through [NodeSource's APT repository](https://nodesource.com/).
  * A build system, git, and development headers for many popular libraries, so that the most popular Ruby, Python and Node.js native extensions can be compiled without problems.
 


### PR DESCRIPTION
Hi,

The README lists Python version 3.0, which is not suitable for my current project (Python 3.4 SSLContext). 

Since this image derives from Ubuntu 14.04 I suspected that the documentation might be out of date, and I decided to check the actual Python version before using a different image:
```
user@dockerhost:~$ docker run --rm -t -i phusion/passenger-full bash -l
root@9e0515ccf45a:/# python3
Python 3.4.0 (default, Jun 19 2015, 14:20:21)
[GCC 4.8.2] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>>
root@9e0515ccf45a:/#
```

I would appreciate it if you update the README to reflect this Python version.