### PR TITLE
Passenger version should be 5 in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Language support:
 Web server and application server:
 
  * Nginx 1.6. Disabled by default.
- * [Phusion Passenger 4](https://www.phusionpassenger.com/). Disabled by default (because it starts along with Nginx).
+ * [Phusion Passenger 5](https://www.phusionpassenger.com/). Disabled by default (because it starts along with Nginx).
    * This is a fast and lightweight tool for simplifying web application integration into Nginx.
    * It adds many production-grade features, such as process monitoring, administration and status inspection.
    * It replaces (G)Unicorn, Thin, Puma, uWSGI.


### PR DESCRIPTION
It looks like the .deb in [the repo](https://oss-binaries.phusionpassenger.com) is running Passenger 5, but the README states version 4.

Found via `docker run -it phusion/passenger-ruby22 bash -c "apt-get update; apt-cache show passenger"`, which reports `Version: 1:5.0.7-1~trusty1`.