### PR TITLE
Fix Python + Node customizable install

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Passenger-docker consists of several images, each one tailor made for a specific
 
 **Node.js and Meteor images**
 
- * `phusion/passenger-nodejs` - Node.js 0.11.
+ * `phusion/passenger-nodejs` - Node.js 0.12.
 
 **Other images**
 
@@ -182,9 +182,7 @@ So put the following in your Dockerfile:
     # If you're using the 'customizable' variant, you need to explicitly opt-in
     # for features. Uncomment the features you want:
     #
-    #   Build system and git.
-    #RUN /pd_build/utilities.sh
-    #   Ruby support.
+    #   Ruby support (packaged with Node support as well).
     #RUN /pd_build/ruby1.9.sh
     #RUN /pd_build/ruby2.0.sh
     #RUN /pd_build/ruby2.1.sh
@@ -192,7 +190,8 @@ So put the following in your Dockerfile:
     #RUN /pd_build/jruby9.0.sh
     #   Python support.
     #RUN /pd_build/python.sh
-    #   Node.js and Meteor support.
+    #   Node.js and Meteor standalone support.
+    #   (not needed if you already have the above Ruby support)
     #RUN /pd_build/nodejs.sh
 
     # ...put your own build instructions here...

--- a/image/nodejs.sh
+++ b/image/nodejs.sh
@@ -4,4 +4,4 @@ source /pd_build/buildconfig
 set -x
 
 ## Install Node.js (also needed for Rails asset compilation)
-apt-get install -y nodejs
+minimal_apt_get_install nodejs

--- a/image/python.sh
+++ b/image/python.sh
@@ -4,4 +4,4 @@ source /pd_build/buildconfig
 set -x
 
 ## Install Python.
-apt-get install -y python python2.7 python3
+minimal_apt_get_install python python2.7 python3


### PR DESCRIPTION
- Use minimal_apt_get_install for apt-get update + --no-install-recommends
- Remove utilities.sh from readme Dockerfile as it's called by default in install.sh
- Add notes about Node being installed with Ruby (in ruby-finalize.sh) in readme
- Update readme to say Node 0.12 consistently (had 0.11 in one place still)

`apt-get update` wasn't called before the `apt-get install` (related to ye old #23 ?), so you'd get this error using the customizable image for Python:

``` stdout
Step 1 : FROM phusion/passenger-customizable:0.9.18
0.9.18: Pulling from phusion/passenger-customizable
...
Digest: sha256:21d6e604230333d144fbea719c8d5ba7ac13b76bb131f55e547e15cdad46e80a
Status: Downloaded newer image for phusion/passenger-customizable:0.9.18
 ---> b77f66d9d073
Step 2 : ENV HOME /root
 ---> Running in 4a6a57d0cd0b
 ---> 29d8993716fc
Removing intermediate container 4a6a57d0cd0b
Step 3 : CMD /sbin/my_init
 ---> Running in 3383c223ae0f
 ---> a1f9d6a2a383
Removing intermediate container 3383c223ae0f
Step 4 : RUN /pd_build/python.sh
 ---> Running in 7b31bfec14e9
+ apt-get install -y python python2.7 python3
Reading package lists...
Building dependency tree...
Reading state information...
Package python is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source

E: Package 'python' has no installation candidate
E: Unable to locate package python2.7
E: Couldn't find any package by regex 'python2.7'
The command '/bin/sh -c /pd_build/python.sh' returned a non-zero code: 100
```

and this for Node:

```
Step 4 : RUN /pd_build/nodejs.sh
 ---> Running in 71567f9798be
+ apt-get install -y nodejs
Reading package lists...
Building dependency tree...
Reading state information...
E: Unable to locate package nodejs
```

+1 for making the `minimal_apt_get_install` function as I end up manually writing that in all my Dockerfiles anyway.

Now it installs fine for Python:

```
...
Step 4 : RUN /pd_build/python.sh
 ---> Running in 3bb438efbb77
+ minimal_apt_get_install -y python python2.7 python3
+ [[ ! -e /var/lib/apt/lists/lock ]]
+ apt-get update
Ign http://archive.ubuntu.com trusty InRelease
...
Fetched 21.7 MB in 1min 48s (200 kB/s)
Reading package lists...
+ apt-get install -y --no-install-recommends python python2.7 python3
Reading package lists...
Building dependency tree...
Reading state information...
python3 is already the newest version.
The following extra packages will be installed:
  libpython-stdlib libpython2.7-minimal libpython2.7-stdlib python-minimal
  python2.7-minimal
Suggested packages:
  python-doc python-tk python2.7-doc binfmt-support
The following NEW packages will be installed:
  libpython-stdlib libpython2.7-minimal libpython2.7-stdlib python
  python-minimal python2.7 python2.7-minimal
0 upgraded, 7 newly installed, 0 to remove and 33 not upgraded.
Need to get 3726 kB of archives.
After this operation, 16.0 MB of additional disk space will be used.
...
```

and Node:

```
...
+ apt-get install -y --no-install-recommends nodejs
Reading package lists...
Building dependency tree...
Reading state information...
The following extra packages will be installed:
  rlwrap
The following NEW packages will be installed:
  nodejs rlwrap
0 upgraded, 2 newly installed, 0 to remove and 33 not upgraded.
....
```

Two follow-up questions: 
1) Opinions on installing `python-pip` with `python` by default? It's an option most Python devs will need anyway and Docker's official Python repo installs it by default (and virtualenv strangely, which doesn't have much use with Docker)
2) Is there a reason there isn't a `passenger-python` image on Docker Hub? I'm using customizable just so I can get Python 2.7 :/
