### PR TITLE
fixes enterprise instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -737,7 +737,7 @@ If you are a [Phusion Passenger Enterprise](https://www.phusionpassenger.com/ent
  3. Insert into your Dockerfile:
 
         ADD passenger-enterprise-license /etc/passenger-enterprise-license
-        RUN echo deb https://download:$DOWNLOAD_TOKEN@www.phusionpassenger.com/enterprise_apt trusty main > /etc/apt/sources.list.d/passenger.list
+        RUN echo deb https://download:$DOWNLOAD_TOKEN@www.phusionpassenger.com/enterprise_apt xenial main > /etc/apt/sources.list.d/passenger.list
         RUN apt-get update && apt-get install -y -o Dpkg::Options::="--force-confold" passenger-enterprise nginx-extras
 
     Replace `$DOWNLOAD_TOKEN` with your actual download token, as found in the Customer Area.


### PR DESCRIPTION
the enterprise install instructions still reference trusty instead of xenial.  Fixed.