### PR TITLE
Updated Rowan's Redis PPA sources.list entry.

### DIFF
--- a/image/enable_repos.sh
+++ b/image/enable_repos.sh
@@ -14,7 +14,7 @@ else
 fi
 
 ## Rowan's Redis PPA
-echo deb http://ppa.launchpad.net/rwky/redis/ubuntu trusty main > /etc/apt/sources.list.d/redis.list
+echo deb http://ppa.launchpad.net/rwky/ppa/ubuntu trusty main > /etc/apt/sources.list.d/redis.list
 
 ## OpenJDK 8 PPA
 echo deb http://ppa.launchpad.net/openjdk-r/ppa/ubuntu trusty main > /etc/apt/sources.list.d/openjdk8.list


### PR DESCRIPTION
Updated Rowan's Redis PPA sources.list entry.

Updated the [PPA in use for Redis](https://launchpad.net/~rwky/+archive/ubuntu/ppa) on older version built for trusty 14.04

Not sure if warrants @FooBarWidget adding `rel-0.9.18.1` or replacing existing... just proposing this as an alternative workaround to what @MSamma mentioned in #171 