### PR TITLE
Add the nodesource repo to the nodejs build so we can use node 7.x.

### DIFF
--- a/image/nodejs.sh
+++ b/image/nodejs.sh
@@ -3,8 +3,15 @@ set -e
 source /pd_build/buildconfig
 set -x
 
+echo "+ Enabling Node Source APT repo"
+run curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
+echo 'deb https://deb.nodesource.com/node_7.x xenial main' > /etc/apt/sources.list.d/nodesource.list
+echo 'deb-src https://deb.nodesource.com/node_7.x xenial main' >> /etc/apt/sources.list.d/nodesource.list && apt-get update
+
 ## Install Node.js (also needed for Rails asset compilation)
-minimal_apt_get_install -y nodejs npm
+minimal_apt_get_install -y nodejs
+echo "+ Updating npm"
+run npm update npm -g
 if [[ ! -e /usr/bin/node ]]; then
 	ln -s /usr/bin/nodejs /usr/bin/node
 fi


### PR DESCRIPTION
npm comes with the nodejs package so a seperate apt-get for it is unnecessary