### PR TITLE
Update README.md for ruby 2.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Passenger-docker consists of several images, each one tailor made for a specific
  * `phusion/passenger-ruby21` - Ruby 2.1.
  * `phusion/passenger-ruby22` - Ruby 2.2.
  * `phusion/passenger-ruby23` - Ruby 2.3.
+ * `phusion/passenger-ruby24` - Ruby 2.4.
  * `phusion/passenger-jruby91` - JRuby 9.1.2.0.
 
 **Node.js and Meteor images**
@@ -174,6 +175,7 @@ So put the following in your Dockerfile:
     #FROM phusion/passenger-ruby21:<VERSION>
     #FROM phusion/passenger-ruby22:<VERSION>
     #FROM phusion/passenger-ruby23:<VERSION>
+    #FROM phusion/passenger-ruby24:<VERSION>
     #FROM phusion/passenger-jruby91:<VERSION>
     #FROM phusion/passenger-nodejs:<VERSION>
     #FROM phusion/passenger-customizable:<VERSION>
@@ -194,6 +196,7 @@ So put the following in your Dockerfile:
     #RUN /pd_build/ruby-2.1.*.sh
     #RUN /pd_build/ruby-2.2.*.sh
     #RUN /pd_build/ruby-2.3.*.sh
+    #RUN /pd_build/ruby-2.4.*.sh
     #RUN /pd_build/jruby-9.1.*.sh
     #   Python support.
     #RUN /pd_build/python.sh
@@ -244,6 +247,8 @@ You can add a virtual host entry (`server` block) by placing a .conf file in the
         passenger_user app;
 
         # If this is a Ruby app, specify a Ruby version:
+        passenger_ruby /usr/bin/ruby2.4;
+        # For Ruby 2.3
         passenger_ruby /usr/bin/ruby2.3;
         # For Ruby 2.2
         passenger_ruby /usr/bin/ruby2.2;


### PR DESCRIPTION
There were a few spots in the README that were missing ruby 2.4 examples. 