### PR TITLE
fix changelog version

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,4 @@
-## 0.9.24 (release date: 2017-08-23)
+## 0.9.25 (release date: 2017-08-23)
 
  * Upgraded to Phusion Passenger 5.1.8 (from 5.1.7).
 


### PR DESCRIPTION
It seems this version is not tagged and not released at [GitHub release page](https://github.com/phusion/passenger-docker/releases).