### PR TITLE
Add instructions for copying the app directory with the correct ownership of app.

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,12 +187,12 @@ So put the following in your Dockerfile:
     CMD ["/sbin/my_init"]
 
     # If you're using the 'customizable' variant, you need to explicitly opt-in
-    # for features. 
+    # for features.
     #
-    # N.B. these images are based on https://github.com/phusion/baseimage-docker, 
-    # so anything it provides is also automatically on board in the images below 
-    # (e.g. older versions of Ruby, Node, Python).  
-    # 
+    # N.B. these images are based on https://github.com/phusion/baseimage-docker,
+    # so anything it provides is also automatically on board in the images below
+    # (e.g. older versions of Ruby, Node, Python).
+    #
     # Uncomment the features you want:
     #
     #   Ruby support
@@ -219,6 +219,8 @@ So put the following in your Dockerfile:
 The image has an `app` user with UID 9999 and home directory `/home/app`. Your application is supposed to run as this user. Even though Docker itself provides some isolation from the host OS, running applications without root privileges is good security practice.
 
 Your application should be placed inside /home/app.
+
+Note: when copying your application, make sure to set the ownership of the application directory to `app` by calling `COPY --chown=app:app /path/to/your/web/app`
 
 <a name="nginx_passenger"></a>
 ### Using Nginx and Passenger
@@ -266,6 +268,7 @@ You can add a virtual host entry (`server` block) by placing a .conf file in the
     ADD webapp.conf /etc/nginx/sites-enabled/webapp.conf
     RUN mkdir /home/app/webapp
     RUN ...commands to place your web app in /home/app/webapp...
+    # COPY --chown=app:app /path/to/your/web/app # This copies your web app with the correct ownership.
 
 <a name="configuring_nginx"></a>
 #### Configuring Nginx

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ The image has an `app` user with UID 9999 and home directory `/home/app`. Your a
 
 Your application should be placed inside /home/app.
 
-Note: when copying your application, make sure to set the ownership of the application directory to `app` by calling `COPY --chown=app:app /path/to/your/web/app`
+Note: when copying your application, make sure to set the ownership of the application directory to `app` by calling `COPY --chown=app:app /local/path/of/your/app /home/app/webapp`
 
 <a name="nginx_passenger"></a>
 ### Using Nginx and Passenger
@@ -268,7 +268,7 @@ You can add a virtual host entry (`server` block) by placing a .conf file in the
     ADD webapp.conf /etc/nginx/sites-enabled/webapp.conf
     RUN mkdir /home/app/webapp
     RUN ...commands to place your web app in /home/app/webapp...
-    # COPY --chown=app:app /path/to/your/web/app # This copies your web app with the correct ownership.
+    # COPY --chown=app:app /local/path/of/your/app /home/app/webapp # This copies your web app with the correct ownership.
 
 <a name="configuring_nginx"></a>
 #### Configuring Nginx


### PR DESCRIPTION
#205 
When copying the app directory over into the image make sure to use the correct ownership that Docker gives you in the `COPY` command, without this the root user owns the directory and can cause permissions issues.
