### PR TITLE
Move comment on README Dockerfile on its own line

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,7 +271,8 @@ You can add a virtual host entry (`server` block) by placing a .conf file in the
     ADD webapp.conf /etc/nginx/sites-enabled/webapp.conf
     RUN mkdir /home/app/webapp
     RUN ...commands to place your web app in /home/app/webapp...
-    # COPY --chown=app:app /local/path/of/your/app /home/app/webapp # This copies your web app with the correct ownership.
+    # This copies your web app with the correct ownership.
+    # COPY --chown=app:app /local/path/of/your/app /home/app/webapp 
 
 <a name="configuring_nginx"></a>
 #### Configuring Nginx


### PR DESCRIPTION
Because there was a comment after a Dockerfile instruction, I had this this cryptic error as a result:
COPY failed: stat /var/lib/docker/tmp/docker-builder779111576/home/app/webapp: no such file or directory
Moving the comment to its own line fixed this.