### PR TITLE
Adds support for ruby 2.6.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ EXTRA_BUILD_FLAGS?=
 
 .PHONY: all build_all \
 	build_customizable \
-	build_ruby23 build_ruby24 build_ruby25 build_jruby92 \
+	build_ruby23 build_ruby24 build_ruby25 build_ruby26 build_jruby92 \
 	build_nodejs build_full \
 	tag_latest release clean clean_images
 
@@ -17,6 +17,7 @@ build_all: \
 	build_ruby23 \
 	build_ruby24 \
 	build_ruby25 \
+	build_ruby26 \
 	build_jruby92 \
 	build_nodejs \
 	build_full
@@ -49,6 +50,13 @@ build_ruby25:
 	echo final=1 >> ruby25_image/buildconfig
 	docker build $(EXTRA_BUILD_FLAGS) -t $(NAME)-ruby25:$(VERSION) --rm ruby25_image --no-cache
 
+build_ruby26:
+	rm -rf ruby26_image
+	cp -pR image ruby26_image
+	echo ruby26=1 >> ruby26_image/buildconfig
+	echo final=1 >> ruby26_image/buildconfig
+	docker build $(EXTRA_BUILD_FLAGS) -t $(NAME)-ruby26:$(VERSION) --rm ruby26_image --no-cache
+
 build_jruby92:
 	rm -rf jruby92_image
 	cp -pR image jruby92_image
@@ -69,6 +77,7 @@ build_full:
 	echo ruby23=1 >> full_image/buildconfig
 	echo ruby24=1 >> full_image/buildconfig
 	echo ruby25=1 >> full_image/buildconfig
+	echo ruby26=1 >> full_image/buildconfig
 	echo jruby92=1 >> full_image/buildconfig
 	echo python=1 >> full_image/buildconfig
 	echo nodejs=1 >> full_image/buildconfig
@@ -82,6 +91,7 @@ tag_latest:
 	docker tag $(NAME)-ruby23:$(VERSION) $(NAME)-ruby23:latest
 	docker tag $(NAME)-ruby24:$(VERSION) $(NAME)-ruby24:latest
 	docker tag $(NAME)-ruby25:$(VERSION) $(NAME)-ruby25:latest
+	docker tag $(NAME)-ruby26:$(VERSION) $(NAME)-ruby26:latest
 	docker tag $(NAME)-jruby92:$(VERSION) $(NAME)-jruby92:latest
 	docker tag $(NAME)-nodejs:$(VERSION) $(NAME)-nodejs:latest
 	docker tag $(NAME)-full:$(VERSION) $(NAME)-full:latest
@@ -91,6 +101,7 @@ release: tag_latest
 	@if ! docker images $(NAME)-ruby23 | awk '{ print $$2 }' | grep -q -F $(VERSION); then echo "$(NAME)-ruby23 version $(VERSION) is not yet built. Please run 'make build'"; false; fi
 	@if ! docker images $(NAME)-ruby24 | awk '{ print $$2 }' | grep -q -F $(VERSION); then echo "$(NAME)-ruby24 version $(VERSION) is not yet built. Please run 'make build'"; false; fi
 	@if ! docker images $(NAME)-ruby25 | awk '{ print $$2 }' | grep -q -F $(VERSION); then echo "$(NAME)-ruby25 version $(VERSION) is not yet built. Please run 'make build'"; false; fi
+	@if ! docker images $(NAME)-ruby26 | awk '{ print $$2 }' | grep -q -F $(VERSION); then echo "$(NAME)-ruby26 version $(VERSION) is not yet built. Please run 'make build'"; false; fi
 	@if ! docker images $(NAME)-jruby92 | awk '{ print $$2 }' | grep -q -F $(VERSION); then echo "$(NAME)-jruby92 version $(VERSION) is not yet built. Please run 'make build'"; false; fi
 	@if ! docker images $(NAME)-nodejs | awk '{ print $$2 }' | grep -q -F $(VERSION); then echo "$(NAME)-nodejs version $(VERSION) is not yet built. Please run 'make build'"; false; fi
 	@if ! docker images $(NAME)-full | awk '{ print $$2 }' | grep -q -F $(VERSION); then echo "$(NAME)-full version $(VERSION) is not yet built. Please run 'make build'"; false; fi
@@ -102,6 +113,8 @@ release: tag_latest
 	docker push $(NAME)-ruby24:$(VERSION)
 	docker push $(NAME)-ruby25:latest
 	docker push $(NAME)-ruby25:$(VERSION)
+	docker push $(NAME)-ruby26:latest
+	docker push $(NAME)-ruby26:$(VERSION)
 	docker push $(NAME)-jruby92:latest
 	docker push $(NAME)-jruby92:$(VERSION)
 	docker push $(NAME)-nodejs:latest
@@ -115,6 +128,7 @@ clean:
 	rm -rf ruby23_image
 	rm -rf ruby24_image
 	rm -rf ruby25_image
+	rm -rf ruby26_image
 	rm -rf jruby92_image
 	rm -rf nodejs_image
 	rm -rf full_image
@@ -124,6 +138,7 @@ clean_images:
 	docker rmi $(NAME)-ruby23:latest $(NAME)-ruby23:$(VERSION) || true
 	docker rmi $(NAME)-ruby24:latest $(NAME)-ruby24:$(VERSION) || true
 	docker rmi $(NAME)-ruby25:latest $(NAME)-ruby25:$(VERSION) || true
+	docker rmi $(NAME)-ruby26:latest $(NAME)-ruby25:$(VERSION) || true
 	docker rmi $(NAME)-jruby92:latest $(NAME)-jruby92:$(VERSION) || true
 	docker rmi $(NAME)-nodejs:latest $(NAME)-nodejs:$(VERSION) || true
 	docker rmi $(NAME)-full:latest $(NAME)-full:$(VERSION) || true

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Basics (learn more at [baseimage-docker](http://phusion.github.io/baseimage-dock
 
 Language support:
 
- * Ruby 2.3.8, 2.4.5 and 2.5.3; JRuby 9.2.0.0.
+ * Ruby 2.3.8, 2.4.5, 2.5.3 and 2.6.0; JRuby 9.2.0.0.
    * RVM is used to manage Ruby versions. [Why RVM?](#why_rvm)
    * 2.5.3 is configured as the default.
    * JRuby is installed from source, but we register an APT entry for it.
@@ -132,6 +132,7 @@ Passenger-docker consists of several images, each one tailor made for a specific
  * `phusion/passenger-ruby23` - Ruby 2.3.
  * `phusion/passenger-ruby24` - Ruby 2.4.
  * `phusion/passenger-ruby25` - Ruby 2.5.
+ * `phusion/passenger-ruby26` - Ruby 2.6.
  * `phusion/passenger-jruby92` - JRuby 9.2.
 
 **Node.js and Meteor images**
@@ -160,7 +161,7 @@ You don't have to download anything manually. The above command will automatical
 <a name="getting_started"></a>
 ### Getting started
 
-There are several images, e.g. `phusion/passenger-ruby25` and `phusion/passenger-nodejs`. Choose the one you want. See [Image variants](#image_variants).
+There are several images, e.g. `phusion/passenger-ruby26` and `phusion/passenger-nodejs`. Choose the one you want. See [Image variants](#image_variants).
 
 So put the following in your Dockerfile:
 
@@ -173,6 +174,7 @@ So put the following in your Dockerfile:
     #FROM phusion/passenger-ruby23:<VERSION>
     #FROM phusion/passenger-ruby24:<VERSION>
     #FROM phusion/passenger-ruby25:<VERSION>
+    #FROM phusion/passenger-ruby26:<VERSION>
     #FROM phusion/passenger-jruby92:<VERSION>
     #FROM phusion/passenger-nodejs:<VERSION>
     #FROM phusion/passenger-customizable:<VERSION>
@@ -248,6 +250,9 @@ You can add a virtual host entry (`server` block) by placing a .conf file in the
         passenger_user app;
 
         # If this is a Ruby app, specify a Ruby version:
+        # For Ruby 2.6
+        passenger_ruby /usr/bin/ruby2.6;
+        # For Ruby 2.5
         passenger_ruby /usr/bin/ruby2.5;
         # For Ruby 2.4
         passenger_ruby /usr/bin/ruby2.4;
@@ -764,6 +769,7 @@ Build one of the images:
     make build_ruby23
     make build_ruby24
     make build_ruby25
+    make build_ruby26
     make build_jruby92
     make build_nodejs
     make build_customizable

--- a/image/install.sh
+++ b/image/install.sh
@@ -9,6 +9,7 @@ run /pd_build/utilities.sh
 if [[ "$ruby23" = 1 ]]; then run /pd_build/ruby-2.3.8.sh; fi
 if [[ "$ruby24" = 1 ]]; then run /pd_build/ruby-2.4.5.sh; fi
 if [[ "$ruby25" = 1 ]]; then run /pd_build/ruby-2.5.3.sh; fi
+if [[ "$ruby26" = 1 ]]; then run /pd_build/ruby-2.6.0.sh; fi
 if [[ "$jruby92" = 1 ]]; then run /pd_build/jruby-9.2.0.0.sh; fi
 if [[ "$python" = 1 ]]; then run /pd_build/python.sh; fi
 if [[ "$nodejs" = 1 ]]; then run /pd_build/nodejs.sh; fi

--- a/image/nginx-passenger.sh
+++ b/image/nginx-passenger.sh
@@ -38,6 +38,10 @@ run cp /pd_build/runit/nginx-log-forwarder /etc/service/nginx-log-forwarder/run
 run sed -i 's|invoke-rc.d nginx rotate|sv 1 nginx|' /etc/logrotate.d/nginx
 
 ## Precompile Ruby extensions.
+if [[ -e /usr/bin/ruby2.6 ]]; then
+	run ruby2.6 -S passenger-config build-native-support
+	run setuser app ruby2.6 -S passenger-config build-native-support
+fi
 if [[ -e /usr/bin/ruby2.5 ]]; then
 	run ruby2.5 -S passenger-config build-native-support
 	run setuser app ruby2.5 -S passenger-config build-native-support

--- a/image/ruby-2.6.0.sh
+++ b/image/ruby-2.6.0.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+source /pd_build/buildconfig
+
+RVM_ID=$(basename "$0" | sed 's/.sh$//')
+
+header "Installing $RVM_ID"
+run /pd_build/ruby_support/prepare.sh
+run /usr/local/rvm/bin/rvm install $RVM_ID
+run /usr/local/rvm/bin/rvm-exec $RVM_ID@global gem install $DEFAULT_RUBY_GEMS --no-document
+# Make passenger_system_ruby work.
+run create_rvm_wrapper_script ruby2.6 $RVM_ID ruby
+run /pd_build/ruby_support/install_ruby_utils.sh
+run /pd_build/ruby_support/finalize.sh

--- a/image/ruby_support/finalize.sh
+++ b/image/ruby_support/finalize.sh
@@ -18,7 +18,9 @@ function set_rvm_default()
 }
 
 known_rubies=`/usr/local/rvm/bin/rvm list strings`
-if [[ "$known_rubies" =~ ^ruby-2\.5 ]]; then
+if [[ "$known_rubies" =~ ^ruby-2\.6 ]]; then
+  set_rvm_default '^ruby-2\.6'
+elif [[ "$known_rubies" =~ ^ruby-2\.5 ]]; then
 	set_rvm_default '^ruby-2\.5'
 elif [[ "$known_rubies" =~ ^ruby-2\.4 ]]; then
 	set_rvm_default '^ruby-2\.4'


### PR DESCRIPTION
https://www.ruby-lang.org/en/news/2018/12/25/ruby-2-6-0-released/

Default is kept at ruby 2.5.3. Not sure if that should change yet