### PR TITLE
update readme re ubuntu os cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -506,10 +506,10 @@ To upgrade the OS in the image, run this in your Dockerfile:
 
 To upgrade the OS in the image, and clean up any unneccessary files, run this in your Dockerfile:
 
-    RUN apt-get update & \
-        apt-get upgrade -y -o Dpkg::Options::="--force-confold" & \
-        apt-get -qy autoremove & \
-        apt-get clean & \
+    RUN apt-get update && \
+        apt-get upgrade -y -o Dpkg::Options::="--force-confold" && \
+        apt-get -qy autoremove && \
+        apt-get clean && \
         rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 <a name="upgrading_passenger"></a>

--- a/README.md
+++ b/README.md
@@ -504,6 +504,14 @@ To upgrade the OS in the image, run this in your Dockerfile:
 
     RUN apt-get update && apt-get upgrade -y -o Dpkg::Options::="--force-confold"
 
+To upgrade the OS in the image, and clean up any unneccessary files, run this in your Dockerfile:
+
+    RUN apt-get update & \
+        apt-get upgrade -y -o Dpkg::Options::="--force-confold" & \
+        apt-get -qy autoremove & \
+        apt-get clean & \
+        rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
 <a name="upgrading_passenger"></a>
 ### Upgrading Passenger to the latest version
 


### PR DESCRIPTION
Referencing https://github.com/DiUS/pact_broker-docker/issues/34

I am using dius's pact broker image and it was bloated after running a forced OS upgrade to 18.04.02.

This PR proposes an update to the readme to provide an option for the user to cleanup old files after an OS forced upgrade 👍 