### PR TITLE
Update buildconfig to remove bundler

### DIFF
--- a/image/buildconfig
+++ b/image/buildconfig
@@ -1,7 +1,7 @@
 export LC_ALL=C
 export DEBIAN_FRONTEND=noninteractive
 
-DEFAULT_RUBY_GEMS='rake bundler rack'
+DEFAULT_RUBY_GEMS='rake rack'
 
 if perl -v >/dev/null 2>/dev/null; then
 	RESET=`perl -e 'print("\e[0m")'`


### PR DESCRIPTION
Bundler is now installed by default with the latest versions of RVM[1]

1. https://github.com/rvm/rvm/pull/4413

fixes #260 