### PR TITLE
Fix README.md: Passenger's version

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Language support:
 Web server and application server:
 
  * Nginx 1.14. Disabled by default.
- * [Phusion Passenger 5](https://www.phusionpassenger.com/). Disabled by default (because it starts along with Nginx).
+ * [Phusion Passenger 6](https://www.phusionpassenger.com/). Disabled by default (because it starts along with Nginx).
    * This is a fast and lightweight tool for simplifying web application integration into Nginx.
    * It adds many production-grade features, such as process monitoring, administration and status inspection.
    * It replaces (G)Unicorn, Thin, Puma, uWSGI.


### PR DESCRIPTION
Now the latest passenger-docker image uses Phusion Passenger 6.