### PR TITLE
install nodejs using the nodejs install script for ruby

### DIFF
--- a/image/ruby_support/install_ruby_utils.sh
+++ b/image/ruby_support/install_ruby_utils.sh
@@ -4,7 +4,7 @@ source /pd_build/buildconfig
 
 ## The Rails asset compiler requires a Javascript runtime.
 if [[ ! -e /usr/bin/node ]]; then
-	run minimal_apt_get_install nodejs
+	/pd_build/nodejs.sh
 fi
 
 ## Install development headers for native libraries that tend to be used often by Ruby gems.


### PR DESCRIPTION
I noticed that it was still using node 10.19.0, in the ruby images. This was preventing us from updating some of our node dependencies, since they want a more recent version of node. This PR updates the install script to install node by just running the nodejs install script used in the nodejs image, instead of just installing node via the default apt.