### PR TITLE
Update docs for enterprise

### DIFF
--- a/README.md
+++ b/README.md
@@ -801,7 +801,7 @@ If you are a [Phusion Passenger Enterprise](https://www.phusionpassenger.com/ent
 ```dockerfile
 ADD passenger-enterprise-license /etc/passenger-enterprise-license
 RUN echo deb https://download:$DOWNLOAD_TOKEN@www.phusionpassenger.com/enterprise_apt $(lsb_release -cs) main > /etc/apt/sources.list.d/passenger.list
- RUN apt-get update && apt-get install -y -o Dpkg::Options::="--force-confold" passenger-enterprise nginx-extras libnginx-mod-http-passenger-enterprise
+RUN apt-get update && apt-get install -y -o Dpkg::Options::="--force-confold" passenger-enterprise nginx-extras libnginx-mod-http-passenger-enterprise
 ```
 
     Replace `$DOWNLOAD_TOKEN` with your actual download token, as found in the Customer Area.

--- a/README.md
+++ b/README.md
@@ -801,7 +801,7 @@ If you are a [Phusion Passenger Enterprise](https://www.phusionpassenger.com/ent
 ```dockerfile
 ADD passenger-enterprise-license /etc/passenger-enterprise-license
 RUN echo deb https://download:$DOWNLOAD_TOKEN@www.phusionpassenger.com/enterprise_apt $(lsb_release -cs) main > /etc/apt/sources.list.d/passenger.list
-RUN apt-get update && apt-get install -y -o Dpkg::Options::="--force-confold" passenger-enterprise nginx-extras
+ RUN apt-get update && apt-get install -y -o Dpkg::Options::="--force-confold" passenger-enterprise nginx-extras libnginx-mod-http-passenger-enterprise
 ```
 
     Replace `$DOWNLOAD_TOKEN` with your actual download token, as found in the Customer Area.


### PR DESCRIPTION
The docs use to say we need to enter these lines to our dockerfile
```
ADD passenger-enterprise-license /etc/passenger-enterprise-license
RUN echo deb https://download:$DOWNLOAD_TOKEN@www.phusionpassenger.com/enterprise_apt $(lsb_release -cs) main > /etc/apt/sources.list.d/passenger.list
RUN apt-get update && apt-get install -y -o Dpkg::Options::="--force-confold" passenger-enterprise nginx-extras
```

But that doesn't work as installing enterprise removes various old packages and replaces them, but it doesn't replace ` libnginx-mod-http-passenger' which leaves us with a missing file.

This took far to long for us to work out but we also needed to install ` libnginx-mod-http-passenger-enterprise`

Just thought you would want to review this and update the docs