### PR TITLE
Add Gihub Action to run make build_all

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: Make
+name: Build all images
 
 on:
   push:
@@ -11,7 +11,7 @@ defaults:
     shell: bash
 
 jobs:
-  run-rspec:
+  build-all:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,25 @@
+name: Make
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  run-rspec:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Purge containers
+        run: 'docker kill $(docker ps -q) || exit 0'
+
+      - name: Run make build_all
+        run: |
+          make build_all


### PR DESCRIPTION
### Why
In some cases running `make build_all` take a lot of time and cannot be finished with success (ex. Apple Silicon).

### What
Lets have free to use GH-action that will starts on every push to `master` branch or on every push to PR into `master`