### PR TITLE
Update CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.1.0 (not yet released)
+## 2.1.0 (release date: 2021-12-07)
  * Upgraded to Ruby 2.6.9
  * Upgraded to Ruby 2.7.5
  * Upgraded to Ruby 3.0.3


### PR DESCRIPTION
2.1.0 was released on Dec. 7th it seems - at that date 2.1.0 images were pushed to docker hub.