### PR TITLE
Add YJIT support by installing `rustc` during Ruby compilation

### DIFF
--- a/image/ruby-3.1.3.sh
+++ b/image/ruby-3.1.3.sh
@@ -10,7 +10,7 @@ run /pd_build/ruby_support/prepare.sh
 # For compiling Ruby with YJIT
 run minimal_apt_get_install rustc
 
-run /usr/local/rvm/bin/rvm install $RVM_ID || ( cat /usr/local/rvm/log/*${RVM_ID}*/*.log && false )
+run /usr/local/rvm/bin/rvm install $RVM_ID --disable-binary || ( cat /usr/local/rvm/log/*${RVM_ID}*/*.log && false )
 run /usr/local/rvm/bin/rvm-exec $RVM_ID@global gem install $DEFAULT_RUBY_GEMS --no-document
 # Make passenger_system_ruby work.
 run create_rvm_wrapper_script ruby3.1 $RVM_ID ruby

--- a/image/ruby-3.1.3.sh
+++ b/image/ruby-3.1.3.sh
@@ -13,7 +13,7 @@ run minimal_apt_get_install rustc
 run /usr/local/rvm/bin/rvm install $RVM_ID --disable-binary || ( cat /usr/local/rvm/log/*${RVM_ID}*/*.log && false )
 
 # Remove rustc after Ruby has compiled with YJIT
-run apt-get remove -y rustc
+run apt-get autoremove -y rustc
 
 run /usr/local/rvm/bin/rvm-exec $RVM_ID@global gem install $DEFAULT_RUBY_GEMS --no-document
 # Make passenger_system_ruby work.

--- a/image/ruby-3.1.3.sh
+++ b/image/ruby-3.1.3.sh
@@ -6,6 +6,10 @@ RVM_ID=$(basename "$0" | sed 's/.sh$//')
 
 header "Installing $RVM_ID"
 run /pd_build/ruby_support/prepare.sh
+
+# For compiling Ruby with YJIT
+run minimal_apt_get_install rustc
+
 run /usr/local/rvm/bin/rvm install $RVM_ID || ( cat /usr/local/rvm/log/*${RVM_ID}*/*.log && false )
 run /usr/local/rvm/bin/rvm-exec $RVM_ID@global gem install $DEFAULT_RUBY_GEMS --no-document
 # Make passenger_system_ruby work.

--- a/image/ruby-3.1.3.sh
+++ b/image/ruby-3.1.3.sh
@@ -11,6 +11,10 @@ run /pd_build/ruby_support/prepare.sh
 run minimal_apt_get_install rustc
 
 run /usr/local/rvm/bin/rvm install $RVM_ID --disable-binary || ( cat /usr/local/rvm/log/*${RVM_ID}*/*.log && false )
+
+# Remove rustc after Ruby has compiled with YJIT
+run apt-get remove -y rustc
+
 run /usr/local/rvm/bin/rvm-exec $RVM_ID@global gem install $DEFAULT_RUBY_GEMS --no-document
 # Make passenger_system_ruby work.
 run create_rvm_wrapper_script ruby3.1 $RVM_ID ruby

--- a/image/ruby-3.2.0.sh
+++ b/image/ruby-3.2.0.sh
@@ -11,6 +11,10 @@ run /pd_build/ruby_support/prepare.sh
 run minimal_apt_get_install rustc
 
 run /usr/local/rvm/bin/rvm install $RVM_ID --disable-binary || ( cat /usr/local/rvm/log/*${RVM_ID}*/*.log && false )
+
+# Remove rustc after Ruby has compiled with YJIT
+run apt-get remove -y rustc
+
 run /usr/local/rvm/bin/rvm-exec $RVM_ID@global gem install $DEFAULT_RUBY_GEMS --no-document
 # Make passenger_system_ruby work.
 run create_rvm_wrapper_script ruby3.2 $RVM_ID ruby

--- a/image/ruby-3.2.0.sh
+++ b/image/ruby-3.2.0.sh
@@ -6,6 +6,10 @@ RVM_ID=$(basename "$0" | sed 's/.sh$//')
 
 header "Installing $RVM_ID"
 run /pd_build/ruby_support/prepare.sh
+
+## For compiling Ruby with YJIT
+run minimal_apt_get_install rustc
+
 run /usr/local/rvm/bin/rvm install $RVM_ID || ( cat /usr/local/rvm/log/*${RVM_ID}*/*.log && false )
 run /usr/local/rvm/bin/rvm-exec $RVM_ID@global gem install $DEFAULT_RUBY_GEMS --no-document
 # Make passenger_system_ruby work.

--- a/image/ruby-3.2.0.sh
+++ b/image/ruby-3.2.0.sh
@@ -10,7 +10,7 @@ run /pd_build/ruby_support/prepare.sh
 # For compiling Ruby with YJIT
 run minimal_apt_get_install rustc
 
-run /usr/local/rvm/bin/rvm install $RVM_ID || ( cat /usr/local/rvm/log/*${RVM_ID}*/*.log && false )
+run /usr/local/rvm/bin/rvm install $RVM_ID --disable-binary || ( cat /usr/local/rvm/log/*${RVM_ID}*/*.log && false )
 run /usr/local/rvm/bin/rvm-exec $RVM_ID@global gem install $DEFAULT_RUBY_GEMS --no-document
 # Make passenger_system_ruby work.
 run create_rvm_wrapper_script ruby3.2 $RVM_ID ruby

--- a/image/ruby-3.2.0.sh
+++ b/image/ruby-3.2.0.sh
@@ -7,7 +7,7 @@ RVM_ID=$(basename "$0" | sed 's/.sh$//')
 header "Installing $RVM_ID"
 run /pd_build/ruby_support/prepare.sh
 
-## For compiling Ruby with YJIT
+# For compiling Ruby with YJIT
 run minimal_apt_get_install rustc
 
 run /usr/local/rvm/bin/rvm install $RVM_ID || ( cat /usr/local/rvm/log/*${RVM_ID}*/*.log && false )

--- a/image/ruby-3.2.0.sh
+++ b/image/ruby-3.2.0.sh
@@ -13,7 +13,7 @@ run minimal_apt_get_install rustc
 run /usr/local/rvm/bin/rvm install $RVM_ID --disable-binary || ( cat /usr/local/rvm/log/*${RVM_ID}*/*.log && false )
 
 # Remove rustc after Ruby has compiled with YJIT
-run apt-get remove -y rustc
+run apt-get autoremove -y rustc
 
 run /usr/local/rvm/bin/rvm-exec $RVM_ID@global gem install $DEFAULT_RUBY_GEMS --no-document
 # Make passenger_system_ruby work.

--- a/image/ruby_support/install_ruby_utils.sh
+++ b/image/ruby_support/install_ruby_utils.sh
@@ -24,8 +24,6 @@ if ! [[ -e /tmp/ruby_native_libs_installed ]]; then
 	run minimal_apt_get_install libpq-dev
 	## For all kinds of stuff.
 	run minimal_apt_get_install zlib1g-dev
-	## For compiling Ruby with YJIT
-	run minimal_apt_get_install rustc
 
 	touch /tmp/ruby_native_libs_installed
 fi

--- a/image/ruby_support/install_ruby_utils.sh
+++ b/image/ruby_support/install_ruby_utils.sh
@@ -24,6 +24,8 @@ if ! [[ -e /tmp/ruby_native_libs_installed ]]; then
 	run minimal_apt_get_install libpq-dev
 	## For all kinds of stuff.
 	run minimal_apt_get_install zlib1g-dev
+	## For compiling Ruby with YJIT
+	run minimal_apt_get_install rustc
 
 	touch /tmp/ruby_native_libs_installed
 fi


### PR DESCRIPTION
To compile Ruby 3.2 with YJIT, [`rustc` is required](https://www.ruby-lang.org/en/news/2022/12/06/ruby-3-2-0-rc1-released/). This PR closes #358

Current master:

```
docker run -it phusion/passenger-ruby32 bash
$ ruby --yjit -ve 'p RubyVM::YJIT.enabled?'
ruby: warning: Ruby was built without YJIT support. You may need to install rustc to build Ruby with YJIT.
ruby 3.2.0 (2022-12-25 revision a528908271) [aarch64-linux]
-e:1:in `<main>': uninitialized constant RubyVM::YJIT (NameError)

p RubyVM::YJIT.enabled?
        ^^^^^^
```

After building the image for this PR locally:

```
make build_ruby32
...
docker run -it phusion/passenger-ruby32:2.5.0-arm64 bash
$ ruby --yjit -ve 'p RubyVM::YJIT.enabled?'
ruby 3.2.0 (2022-12-25 revision a528908271) +YJIT [aarch64-linux]
true
```