### PR TITLE
Reduce time required to build_all with a temporary base image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+Dockerfile
+Dockerfile.base

--- a/Makefile
+++ b/Makefile
@@ -39,71 +39,78 @@ labels:
 	@echo $(NAME)-full:$(VERSION)-amd64 $(NAME)-full:latest-amd64
 	@echo $(NAME)-full:$(VERSION)-arm64 $(NAME)-full:latest-arm64
 
+build_base:
+	docker rmi $(NAME)-base:current-amd64 || true
+	docker rmi $(NAME)-base:current-arm64 || true
+	docker buildx build --progress=plain --platform linux/amd64 $(EXTRA_BUILD_FLAGS) -t $(NAME)-base:current-amd64 -f image/Dockerfile.base image --no-cache
+	docker buildx build --progress=plain --platform linux/arm64 $(EXTRA_BUILD_FLAGS) -t $(NAME)-base:current-arm64 -f image/Dockerfile.base image --no-cache
+
 # Docker doesn't support sharing files between different Dockerfiles. -_-
 # So we copy things around.
-build_customizable:
+
+build_customizable: build_base
 	rm -rf customizable_image
 	cp -pR image customizable_image
-	docker buildx build --progress=plain --platform linux/amd64 $(EXTRA_BUILD_FLAGS) -t $(NAME)-customizable:$(VERSION)-amd64 --rm customizable_image --no-cache
-	docker buildx build --progress=plain --platform linux/arm64 $(EXTRA_BUILD_FLAGS) -t $(NAME)-customizable:$(VERSION)-arm64 --rm customizable_image --no-cache
+	docker buildx build --progress=plain --platform linux/amd64 $(EXTRA_BUILD_FLAGS) --build-arg ARCH=amd64 -t $(NAME)-customizable:$(VERSION)-amd64 --rm customizable_image --no-cache
+	docker buildx build --progress=plain --platform linux/arm64 $(EXTRA_BUILD_FLAGS) --build-arg ARCH=arm64 -t $(NAME)-customizable:$(VERSION)-arm64 --rm customizable_image --no-cache
 
-build_ruby27:
+build_ruby27: build_base
 	rm -rf ruby27_image
 	cp -pR image ruby27_image
 	echo ruby27=1 >> ruby27_image/buildconfig
 	echo final=1 >> ruby27_image/buildconfig
-	docker buildx build --progress=plain --platform linux/amd64 $(EXTRA_BUILD_FLAGS) -t $(NAME)-ruby27:$(VERSION)-amd64 --rm ruby27_image --no-cache
-	docker buildx build --progress=plain --platform linux/arm64 $(EXTRA_BUILD_FLAGS) -t $(NAME)-ruby27:$(VERSION)-arm64 --rm ruby27_image --no-cache
+	docker buildx build --progress=plain --platform linux/amd64 $(EXTRA_BUILD_FLAGS) --build-arg ARCH=amd64 -t $(NAME)-ruby27:$(VERSION)-amd64 --rm ruby27_image --no-cache
+	docker buildx build --progress=plain --platform linux/arm64 $(EXTRA_BUILD_FLAGS) --build-arg ARCH=arm64 -t $(NAME)-ruby27:$(VERSION)-arm64 --rm ruby27_image --no-cache
 
-build_ruby30:
+build_ruby30: build_base
 	rm -rf ruby30_image
 	cp -pR image ruby30_image
 	echo ruby30=1 >> ruby30_image/buildconfig
 	echo final=1 >> ruby30_image/buildconfig
-	docker buildx build --progress=plain --platform linux/amd64 $(EXTRA_BUILD_FLAGS) -t $(NAME)-ruby30:$(VERSION)-amd64 --rm ruby30_image --no-cache
-	docker buildx build --progress=plain --platform linux/arm64 $(EXTRA_BUILD_FLAGS) -t $(NAME)-ruby30:$(VERSION)-arm64 --rm ruby30_image --no-cache
+	docker buildx build --progress=plain --platform linux/amd64 $(EXTRA_BUILD_FLAGS) --build-arg ARCH=amd64 -t $(NAME)-ruby30:$(VERSION)-amd64 --rm ruby30_image --no-cache
+	docker buildx build --progress=plain --platform linux/arm64 $(EXTRA_BUILD_FLAGS) --build-arg ARCH=arm64 -t $(NAME)-ruby30:$(VERSION)-arm64 --rm ruby30_image --no-cache
 
-build_ruby31:
+build_ruby31: build_base
 	rm -rf ruby31_image
 	cp -pR image ruby31_image
 	echo ruby31=1 >> ruby31_image/buildconfig
 	echo final=1 >> ruby31_image/buildconfig
-	docker buildx build --progress=plain --platform linux/amd64 $(EXTRA_BUILD_FLAGS) -t $(NAME)-ruby31:$(VERSION)-amd64 --rm ruby31_image --no-cache
-	docker buildx build --progress=plain --platform linux/arm64 $(EXTRA_BUILD_FLAGS) -t $(NAME)-ruby31:$(VERSION)-arm64 --rm ruby31_image --no-cache
+	docker buildx build --progress=plain --platform linux/amd64 $(EXTRA_BUILD_FLAGS) --build-arg ARCH=amd64 -t $(NAME)-ruby31:$(VERSION)-amd64 --rm ruby31_image --no-cache
+	docker buildx build --progress=plain --platform linux/arm64 $(EXTRA_BUILD_FLAGS) --build-arg ARCH=arm64 -t $(NAME)-ruby31:$(VERSION)-arm64 --rm ruby31_image --no-cache
 
-build_ruby32:
+build_ruby32: build_base
 	rm -rf ruby32_image
 	cp -pR image ruby32_image
 	echo ruby32=1 >> ruby32_image/buildconfig
 	echo final=1 >> ruby32_image/buildconfig
-	docker buildx build --progress=plain --platform linux/amd64 $(EXTRA_BUILD_FLAGS) -t $(NAME)-ruby32:$(VERSION)-amd64 --rm ruby32_image --no-cache
-	docker buildx build --progress=plain --platform linux/arm64 $(EXTRA_BUILD_FLAGS) -t $(NAME)-ruby32:$(VERSION)-arm64 --rm ruby32_image --no-cache
+	docker buildx build --progress=plain --platform linux/amd64 $(EXTRA_BUILD_FLAGS) --build-arg ARCH=amd64 -t $(NAME)-ruby32:$(VERSION)-amd64 --rm ruby32_image --no-cache
+	docker buildx build --progress=plain --platform linux/arm64 $(EXTRA_BUILD_FLAGS) --build-arg ARCH=arm64 -t $(NAME)-ruby32:$(VERSION)-arm64 --rm ruby32_image --no-cache
 
-build_jruby93:
+build_jruby93: build_base
 	rm -rf jruby93_image
 	cp -pR image jruby93_image
 	echo jruby93=1 >> jruby93_image/buildconfig
 	echo final=1 >> jruby93_image/buildconfig
-	docker buildx build --progress=plain --platform linux/amd64 $(EXTRA_BUILD_FLAGS) -t $(NAME)-jruby93:$(VERSION)-amd64 --rm jruby93_image --no-cache
-	docker buildx build --progress=plain --platform linux/arm64 $(EXTRA_BUILD_FLAGS) -t $(NAME)-jruby93:$(VERSION)-arm64 --rm jruby93_image --no-cache
+	docker buildx build --progress=plain --platform linux/amd64 $(EXTRA_BUILD_FLAGS) --build-arg ARCH=amd64 -t $(NAME)-jruby93:$(VERSION)-amd64 --rm jruby93_image --no-cache
+	docker buildx build --progress=plain --platform linux/arm64 $(EXTRA_BUILD_FLAGS) --build-arg ARCH=arm64 -t $(NAME)-jruby93:$(VERSION)-arm64 --rm jruby93_image --no-cache
 
-build_jruby94:
+build_jruby94: build_base
 	rm -rf jruby94_image
 	cp -pR image jruby94_image
 	echo jruby94=1 >> jruby94_image/buildconfig
 	echo final=1 >> jruby94_image/buildconfig
-	docker buildx build --progress=plain --platform linux/amd64 $(EXTRA_BUILD_FLAGS) -t $(NAME)-jruby94:$(VERSION)-amd64 --rm jruby94_image --no-cache
-	docker buildx build --progress=plain --platform linux/arm64 $(EXTRA_BUILD_FLAGS) -t $(NAME)-jruby94:$(VERSION)-arm64 --rm jruby94_image --no-cache
+	docker buildx build --progress=plain --platform linux/amd64 $(EXTRA_BUILD_FLAGS) --build-arg ARCH=amd64 -t $(NAME)-jruby94:$(VERSION)-amd64 --rm jruby94_image --no-cache
+	docker buildx build --progress=plain --platform linux/arm64 $(EXTRA_BUILD_FLAGS) --build-arg ARCH=arm64 -t $(NAME)-jruby94:$(VERSION)-arm64 --rm jruby94_image --no-cache
 
-build_nodejs:
+build_nodejs: build_base
 	rm -rf nodejs_image
 	cp -pR image nodejs_image
 	echo nodejs=1 >> nodejs_image/buildconfig
 	echo final=1 >> nodejs_image/buildconfig
-	docker buildx build --progress=plain --platform linux/amd64 $(EXTRA_BUILD_FLAGS) -t $(NAME)-nodejs:$(VERSION)-amd64 --rm nodejs_image --no-cache
-	docker buildx build --progress=plain --platform linux/arm64 $(EXTRA_BUILD_FLAGS) -t $(NAME)-nodejs:$(VERSION)-arm64 --rm nodejs_image --no-cache
+	docker buildx build --progress=plain --platform linux/amd64 $(EXTRA_BUILD_FLAGS) --build-arg ARCH=amd64 -t $(NAME)-nodejs:$(VERSION)-amd64 --rm nodejs_image --no-cache
+	docker buildx build --progress=plain --platform linux/arm64 $(EXTRA_BUILD_FLAGS) --build-arg ARCH=arm64 -t $(NAME)-nodejs:$(VERSION)-arm64 --rm nodejs_image --no-cache
 
-build_full:
+build_full: build_base
 	rm -rf full_image
 	cp -pR image full_image
 	echo ruby27=1 >> full_image/buildconfig
@@ -117,8 +124,8 @@ build_full:
 	echo redis=1 >> full_image/buildconfig
 	echo memcached=1 >> full_image/buildconfig
 	echo final=1 >> full_image/buildconfig
-	docker buildx build  --platform linux/amd64 $(EXTRA_BUILD_FLAGS) -t $(NAME)-full:$(VERSION)-amd64 --rm full_image --no-cache
-	docker buildx build  --platform linux/arm64 $(EXTRA_BUILD_FLAGS) -t $(NAME)-full:$(VERSION)-arm64 --rm full_image --no-cache
+	docker buildx build --progress=plain --platform linux/amd64 $(EXTRA_BUILD_FLAGS) --build-arg ARCH=amd64 -t $(NAME)-full:$(VERSION)-amd64 --rm full_image --no-cache
+	docker buildx build --progress=plain --platform linux/arm64 $(EXTRA_BUILD_FLAGS) --build-arg ARCH=arm64 -t $(NAME)-full:$(VERSION)-arm64 --rm full_image --no-cache
 
 tag_latest:
 	@if ! docker images $(NAME)-customizable | awk '{ print $$2 }' | grep -q -F $(VERSION)-amd64; then echo "$(NAME)-customizable version $(VERSION)-amd64 is not yet built. Please run 'make build'"; false; fi
@@ -276,3 +283,5 @@ clean_images:
 	docker rmi $(NAME)-nodejs:latest-arm64 $(NAME)-nodejs:$(VERSION)-arm64 || true
 	docker rmi $(NAME)-full:latest-amd64 $(NAME)-full:$(VERSION)-amd64 || true
 	docker rmi $(NAME)-full:latest-arm64 $(NAME)-full:$(VERSION)-arm64 || true
+	docker rmi $(NAME)-base:current-amd64 || true
+	docker rmi $(NAME)-base:current-arm64 || true

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -1,7 +1,10 @@
-FROM phusion/baseimage:master
+ARG ARCH
+FROM phusion/passenger-base:current-$ARCH
 MAINTAINER Phusion <info@phusion.nl>
 
 ADD . /pd_build
-RUN /pd_build/install.sh
+
+RUN /pd_build/install_image.sh
+
 CMD ["/sbin/my_init"]
 EXPOSE 80 443

--- a/image/Dockerfile.base
+++ b/image/Dockerfile.base
@@ -1,0 +1,7 @@
+FROM phusion/baseimage:master
+MAINTAINER Phusion <info@phusion.nl>
+
+ADD . /pd_build
+
+RUN /pd_build/install_base.sh && \
+    rm -rf /pd_build

--- a/image/buildconfig
+++ b/image/buildconfig
@@ -28,6 +28,12 @@ function minimal_apt_get_install()
 	apt-get install -y --no-install-recommends "$@"
 }
 
+function cleanup_apt()
+{
+	run apt-get -y clean
+	run rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /var/log/dpkg.log /var/log/apt/*
+}
+
 function header()
 {
 	local title="$1"

--- a/image/finalize.sh
+++ b/image/finalize.sh
@@ -10,8 +10,7 @@ fi
 
 run apt-get remove -y autoconf automake
 run apt-get autoremove -y
-run apt-get clean
-run rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
 if [[ "$final" = 1 ]]; then
 	run rm -rf /pd_build
 else

--- a/image/install_base.sh
+++ b/image/install_base.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+source /pd_build/buildconfig
+
+run /pd_build/enable_repos.sh
+run /pd_build/update_baseimage.sh
+run /pd_build/prepare.sh
+run /pd_build/utilities.sh
+
+cleanup_apt

--- a/image/install_image.sh
+++ b/image/install_image.sh
@@ -2,10 +2,8 @@
 set -e
 source /pd_build/buildconfig
 
-run /pd_build/enable_repos.sh
-run /pd_build/update_os.sh
-run /pd_build/prepare.sh
-run /pd_build/utilities.sh
+# base cleans up apt before here now
+run apt-get update
 
 if [[ "$ruby27" = 1 ]]; then run /pd_build/ruby-2.7.*.sh; fi
 if [[ "$ruby30" = 1 ]]; then run /pd_build/ruby-3.0.*.sh; fi
@@ -22,3 +20,5 @@ if [[ "$memcached" = 1 ]]; then run /pd_build/memcached.sh; fi
 run /pd_build/nginx-passenger.sh
 
 run /pd_build/finalize.sh
+
+cleanup_apt

--- a/image/update_baseimage.sh
+++ b/image/update_baseimage.sh
@@ -2,6 +2,6 @@
 set -e
 source /pd_build/buildconfig
 
-header "Installing OS updates"
+header "Installing baseimage updates"
 
 run apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" upgrade


### PR DESCRIPTION
make build_all on current master takes ~288 minutes on my system

With this PR, that drops to ~220 minutes. It also avoids downloading ~1900 packages from the Ubuntu mirrors.

Building a single image will take a few seconds longer, but any additional image in the same build cycle will be noticeably faster, especially in the not-native arch where even dpkg is slow.

The output images should be more or less identical to current master. I did add some dpkg log cleanup, though, but that should be the only effective difference.

Feedback welcome. I tried a few different ways to accomplish this and this was the least intrusive, but I'm not going to claim to be a docker expert.