### PR TITLE
Replace Node 16 LTS with 18 LTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Language support:
    * JRuby is installed from source, but we register an APT entry for it.
    * JRuby uses OpenJDK 17.
  * Python 2.7 and Python 3.8.
- * Node.js 16.
+ * Node.js 18.
  * A build system, git, and development headers for many popular libraries, so that the most popular Ruby, Python and Node.js native extensions can be compiled without problems.
 
 Web server and application server:
@@ -138,7 +138,7 @@ Passenger-docker consists of several images, each one tailor made for a specific
 
 **Node.js and Meteor images**
 
- * `phusion/passenger-nodejs` - Node.js 16.
+ * `phusion/passenger-nodejs` - Node.js 18.
 
 **Other images**
 

--- a/image/nodejs.sh
+++ b/image/nodejs.sh
@@ -4,7 +4,7 @@ source /pd_build/buildconfig
 set -x
 
 echo "+ Enabling Node Source APT repo"
-curl -sL https://deb.nodesource.com/setup_16.x | bash -
+curl -sL https://deb.nodesource.com/setup_18.x | bash -
 apt-get update
 
 ## Install Node.js (also needed for Rails asset compilation)


### PR DESCRIPTION
As noted in this ![issue](https://github.com/phusion/passenger-docker/issues/363) the LTS version of 18 has been active since October of 2022. In addition v16 will be hitting end of life in September of this year. 