### PR TITLE
chore(baseimage): Updating OS to Jammy

### DIFF
--- a/image/Dockerfile.base
+++ b/image/Dockerfile.base
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.2
-FROM phusion/baseimage:master
+FROM phusion/baseimage:jammy-1.0.1
 MAINTAINER Phusion <info@phusion.nl>
 
 ADD . /pd_build


### PR DESCRIPTION
The last used docker tag was 10 months old.

Fixes https://github.com/phusion/passenger-docker/issues/350