### PR TITLE
Migrate nodesource to new repository

### DIFF
--- a/image/nodejs.sh
+++ b/image/nodejs.sh
@@ -4,8 +4,13 @@ source /pd_build/buildconfig
 set -x
 
 echo "+ Enabling Node Source APT repo"
-curl -sL https://deb.nodesource.com/setup_18.x | bash -
-apt-get update
+NODE_MAJOR=18
+sudo apt-get update
+sudo apt-get install -y ca-certificates curl gnupg
+mkdir -p /etc/apt/keyrings
+curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_${NODE_MAJOR}.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
+sudo apt-get update
 
 ## Install Node.js (also needed for Rails asset compilation)
 minimal_apt_get_install nodejs


### PR DESCRIPTION
I've knocked together an (untested) PR for https://github.com/phusion/passenger-docker/issues/374 in the hope that it might be of use

The code is based on nodesource's migration guide; https://github.com/nodesource/distributions/wiki/How-to-migrate-to-the-new-repository