### PR TITLE
Use latest openssl 1.1.1w (only with Ruby 3.0)

### DIFF
--- a/image/install_openssl1.1.sh
+++ b/image/install_openssl1.1.sh
@@ -5,8 +5,8 @@ set -e
 if [[ ! -d /usr/local/ssl ]]; then
 	PWD=$(pwd)
 	cd /usr/local/src/
-	git clone https://github.com/openssl/openssl.git -b OpenSSL_1_1_1-stable openssl-1.1.1m
-	cd openssl-1.1.1m
+	git clone https://github.com/openssl/openssl.git -b OpenSSL_1_1_1-stable openssl-1.1.1w
+	cd openssl-1.1.1w
 	./config --prefix=/usr/local/ssl --openssldir=/usr/local/ssl shared zlib
 	make -j$(nproc)
 	make install_sw


### PR DESCRIPTION
This just updates the self-built OpenSSL 1.1.1 used for Ruby 3.0 .