### PR TITLE
QoL improvements for working on or self-hosting image

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,10 +38,11 @@ jobs:
       - name: Log in to the Container registry
         if: ${{ github.event.pull_request.merged || github.actor == 'CamJN' }}
         uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        id: login
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Push to github container registry
-        if: ${{ success() }}
+        if: ${{ success() && steps.login.conclusion != 'skipped' }}
         run: "make release_${{ matrix.img }}"

--- a/Makefile
+++ b/Makefile
@@ -30,66 +30,22 @@ ifeq (${BUILD_ARM64},0)
 undefine _build_arm64
 endif
 
-.PHONY: all build_all release clean clean_images labels tag_latest push build_customizable build_ruby30 build_ruby31 build_ruby32 build_jruby93 build_jruby94 build_nodejs build_full
+.PHONY: all build_base build_all tag_latest cross_tag push release labels clean clean_images
+
+FORCE:
+
+SPECIAL_IMAGES:= customizable full
+SINGLE_VERSION_IMAGES := jruby93 jruby94 nodejs ruby30 ruby31 ruby32
 
 all: build_all
 
-# waits are to ensure that we only compile each version of ruby once per arch
+# waits are to ensure that we only compile each version of ruby once per arch when even if running parallel
 build_all: \
 	build_customizable \
 	.WAIT \
-	build_jruby93 \
-	build_jruby94 \
-	build_nodejs \
-	build_ruby30 \
-	build_ruby31 \
-	build_ruby32 \
+	$(foreach image, $(SINGLE_VERSION_IMAGES), build_${image}) \
 	.WAIT \
 	build_full
-
-labels:
-ifdef _build_amd64
-	@echo $(NAME)-customizable:$(VERSION)-amd64 $(NAME)-customizable:latest-amd64
-	@echo $(NAME)-ruby30:$(VERSION)-amd64 $(NAME)-ruby30:latest-amd64
-	@echo $(NAME)-ruby31:$(VERSION)-amd64 $(NAME)-ruby31:latest-amd64
-	@echo $(NAME)-ruby32:$(VERSION)-amd64 $(NAME)-ruby32:latest-amd64
-	@echo $(NAME)-jruby93:$(VERSION)-amd64 $(NAME)-jruby93:latest-amd64
-	@echo $(NAME)-jruby94:$(VERSION)-amd64 $(NAME)-jruby94:latest-amd64
-	@echo $(NAME)-nodejs:$(VERSION)-amd64 $(NAME)-nodejs:latest-amd64
-	@echo $(NAME)-full:$(VERSION)-amd64 $(NAME)-full:latest-amd64
-endif
-ifdef _build_arm64
-	@echo $(NAME)-customizable:$(VERSION)-arm64 $(NAME)-customizable:latest-arm64
-	@echo $(NAME)-ruby30:$(VERSION)-arm64 $(NAME)-ruby30:latest-arm64
-	@echo $(NAME)-ruby31:$(VERSION)-arm64 $(NAME)-ruby31:latest-arm64
-	@echo $(NAME)-ruby32:$(VERSION)-arm64 $(NAME)-ruby32:latest-arm64
-	@echo $(NAME)-jruby93:$(VERSION)-arm64 $(NAME)-jruby93:latest-arm64
-	@echo $(NAME)-jruby94:$(VERSION)-arm64 $(NAME)-jruby94:latest-arm64
-	@echo $(NAME)-nodejs:$(VERSION)-arm64 $(NAME)-nodejs:latest-arm64
-	@echo $(NAME)-full:$(VERSION)-arm64 $(NAME)-full:latest-arm64
-endif
-
-pull:
-ifdef _build_amd64
-	docker pull $(NAME)-customizable:$(VERSION)-amd64
-	docker pull $(NAME)-ruby30:$(VERSION)-amd64
-	docker pull $(NAME)-ruby31:$(VERSION)-amd64
-	docker pull $(NAME)-ruby32:$(VERSION)-amd64
-	docker pull $(NAME)-jruby93:$(VERSION)-amd64
-	docker pull $(NAME)-jruby94:$(VERSION)-amd64
-	docker pull $(NAME)-nodejs:$(VERSION)-amd64
-	docker pull $(NAME)-full:$(VERSION)-amd64
-endif
-ifdef _build_arm64
-	docker pull $(NAME)-customizable:$(VERSION)-arm64
-	docker pull $(NAME)-ruby30:$(VERSION)-arm64
-	docker pull $(NAME)-ruby31:$(VERSION)-arm64
-	docker pull $(NAME)-ruby32:$(VERSION)-arm64
-	docker pull $(NAME)-jruby93:$(VERSION)-arm64
-	docker pull $(NAME)-jruby94:$(VERSION)-arm64
-	docker pull $(NAME)-nodejs:$(VERSION)-arm64
-	docker pull $(NAME)-full:$(VERSION)-arm64
-endif
 
 build_base:
 	rm -rf base_image
@@ -104,367 +60,97 @@ ifdef _build_arm64
 endif
 	rm -rf base_image
 
-# Docker doesn't support sharing files between different Dockerfiles. -_-
-# So we copy things around.
-
-build_customizable: build_base
-	rm -rf customizable_image
-	cp -pR image customizable_image
+build_%: build_base
+	rm -rf $*_image
+	cp -pR image $*_image
+	@if [ "${*}" != "full" ] && [ "${*}" != "customizable" ]; then \
+	    echo "${*}=1" >> ${*}_image/buildconfig; \
+	fi
+	@if [ "${*}" == "full" ]; then \
+	    for i in ${SINGLE_VERSION_IMAGES}; do echo "$${i}=1" >> ${*}_image/buildconfig; done; \
+	    echo python=1 >> ${*}_image/buildconfig; \
+	    echo redis=1 >> ${*}_image/buildconfig; \
+	    echo memcached=1 >> ${*}_image/buildconfig; \
+	fi
+	@if [ "${*}" != "customizable" ]; then \
+	    echo final=1 >> ${*}_image/buildconfig; \
+	fi
 ifdef _build_amd64
-	docker buildx build --progress=plain --platform linux/amd64 $(EXTRA_BUILD_FLAGS) --build-arg REGISTRY=$(REGISTRY) --build-arg ARCH=amd64 -t $(NAME)-customizable:$(VERSION)-amd64 --rm customizable_image
+	docker buildx build --progress=plain --platform linux/amd64 $(EXTRA_BUILD_FLAGS) --build-arg REGISTRY=$(REGISTRY) --build-arg ARCH=amd64 -t $(NAME)-$*:$(VERSION)-amd64 --rm $*_image
 endif
 ifdef _build_arm64
-	docker buildx build --progress=plain --platform linux/arm64 $(EXTRA_BUILD_FLAGS) --build-arg REGISTRY=$(REGISTRY) --build-arg ARCH=arm64 -t $(NAME)-customizable:$(VERSION)-arm64 --rm customizable_image
+	docker buildx build --progress=plain --platform linux/arm64 $(EXTRA_BUILD_FLAGS) --build-arg REGISTRY=$(REGISTRY) --build-arg ARCH=arm64 -t $(NAME)-$*:$(VERSION)-arm64 --rm $*_image
 endif
 
-build_ruby30: build_base
-	rm -rf ruby30_image
-	cp -pR image ruby30_image
-	echo ruby30=1 >> ruby30_image/buildconfig
-	echo final=1 >> ruby30_image/buildconfig
+labels: $(foreach image, $(SINGLE_VERSION_IMAGES), label_${image}) $(foreach image, $(SPECIAL_IMAGES), label_${image})
+
+label_%: FORCE
 ifdef _build_amd64
-	docker buildx build --progress=plain --platform linux/amd64 $(EXTRA_BUILD_FLAGS) --build-arg REGISTRY=$(REGISTRY) --build-arg ARCH=amd64 -t $(NAME)-ruby30:$(VERSION)-amd64 --rm ruby30_image
+	@echo $(NAME)-$*:$(VERSION)-amd64 $(NAME)-$*:latest-amd64
 endif
 ifdef _build_arm64
-	docker buildx build --progress=plain --platform linux/arm64 $(EXTRA_BUILD_FLAGS) --build-arg REGISTRY=$(REGISTRY) --build-arg ARCH=arm64 -t $(NAME)-ruby30:$(VERSION)-arm64 --rm ruby30_image
+	@echo $(NAME)-$*:$(VERSION)-arm64 $(NAME)-$*:latest-arm64
 endif
 
-build_ruby31: build_base
-	rm -rf ruby31_image
-	cp -pR image ruby31_image
-	echo ruby31=1 >> ruby31_image/buildconfig
-	echo final=1 >> ruby31_image/buildconfig
+pull: $(foreach image, $(SINGLE_VERSION_IMAGES), pull_${image}) $(foreach image, $(SPECIAL_IMAGES), pull_${image})
+
+pull_%: FORCE
 ifdef _build_amd64
-	docker buildx build --progress=plain --platform linux/amd64 $(EXTRA_BUILD_FLAGS) --build-arg REGISTRY=$(REGISTRY) --build-arg ARCH=amd64 -t $(NAME)-ruby31:$(VERSION)-amd64 --rm ruby31_image
+	docker pull $(NAME)-$*:$(VERSION)-amd64
 endif
 ifdef _build_arm64
-	docker buildx build --progress=plain --platform linux/arm64 $(EXTRA_BUILD_FLAGS) --build-arg REGISTRY=$(REGISTRY) --build-arg ARCH=arm64 -t $(NAME)-ruby31:$(VERSION)-arm64 --rm ruby31_image
+	docker pull $(NAME)-$*:$(VERSION)-arm64
 endif
 
-build_ruby32: build_base
-	rm -rf ruby32_image
-	cp -pR image ruby32_image
-	echo ruby32=1 >> ruby32_image/buildconfig
-	echo final=1 >> ruby32_image/buildconfig
+cross_tag: $(foreach image, $(SINGLE_VERSION_IMAGES), cross_tag_${image}) $(foreach image, $(SPECIAL_IMAGES), cross_tag_${image})
+
+cross_tag_%: FORCE
 ifdef _build_amd64
-	docker buildx build --progress=plain --platform linux/amd64 $(EXTRA_BUILD_FLAGS) --build-arg REGISTRY=$(REGISTRY) --build-arg ARCH=amd64 -t $(NAME)-ruby32:$(VERSION)-amd64 --rm ruby32_image
+	docker tag ghcr.io/phusion/passenger-$*:$(VERSION)-amd64 $(NAME)-$*:$(VERSION)-amd64
 endif
 ifdef _build_arm64
-	docker buildx build --progress=plain --platform linux/arm64 $(EXTRA_BUILD_FLAGS) --build-arg REGISTRY=$(REGISTRY) --build-arg ARCH=arm64 -t $(NAME)-ruby32:$(VERSION)-arm64 --rm ruby32_image
+	docker tag ghcr.io/phusion/passenger-$*:$(VERSION)-arm64 $(NAME)-$*:$(VERSION)-arm64
 endif
 
-build_jruby93: build_base
-	rm -rf jruby93_image
-	cp -pR image jruby93_image
-	echo jruby93=1 >> jruby93_image/buildconfig
-	echo final=1 >> jruby93_image/buildconfig
+tag_latest: $(foreach image, $(SINGLE_VERSION_IMAGES), tag_latest_${image}) $(foreach image, $(SPECIAL_IMAGES), tag_latest_${image})
+
+tag_latest_%: FORCE
 ifdef _build_amd64
-	docker buildx build --progress=plain --platform linux/amd64 $(EXTRA_BUILD_FLAGS) --build-arg REGISTRY=$(REGISTRY) --build-arg ARCH=amd64 -t $(NAME)-jruby93:$(VERSION)-amd64 --rm jruby93_image
+	docker tag $(NAME)-$*:$(VERSION)-amd64 $(NAME)-$*:latest-amd64
 endif
 ifdef _build_arm64
-	docker buildx build --progress=plain --platform linux/arm64 $(EXTRA_BUILD_FLAGS) --build-arg REGISTRY=$(REGISTRY) --build-arg ARCH=arm64 -t $(NAME)-jruby93:$(VERSION)-arm64 --rm jruby93_image
+	docker tag $(NAME)-$*:$(VERSION)-arm64 $(NAME)-$*:latest-arm64
 endif
 
-build_jruby94: build_base
-	rm -rf jruby94_image
-	cp -pR image jruby94_image
-	echo jruby94=1 >> jruby94_image/buildconfig
-	echo final=1 >> jruby94_image/buildconfig
+push: $(foreach image, $(SINGLE_VERSION_IMAGES), push_${image}) $(foreach image, $(SPECIAL_IMAGES), push_${image})
+
+push_%: tag_latest_%
 ifdef _build_amd64
-	docker buildx build --progress=plain --platform linux/amd64 $(EXTRA_BUILD_FLAGS) --build-arg REGISTRY=$(REGISTRY) --build-arg ARCH=amd64 -t $(NAME)-jruby94:$(VERSION)-amd64 --rm jruby94_image
+	docker push $(NAME)-$*:latest-amd64
+	docker push $(NAME)-$*:$(VERSION)-amd64
 endif
 ifdef _build_arm64
-	docker buildx build --progress=plain --platform linux/arm64 $(EXTRA_BUILD_FLAGS) --build-arg REGISTRY=$(REGISTRY) --build-arg ARCH=arm64 -t $(NAME)-jruby94:$(VERSION)-arm64 --rm jruby94_image
+	docker push $(NAME)-$*:latest-arm64
+	docker push $(NAME)-$*:$(VERSION)-arm64
 endif
 
-build_nodejs: build_base
-	rm -rf nodejs_image
-	cp -pR image nodejs_image
-	echo nodejs=1 >> nodejs_image/buildconfig
-	echo final=1 >> nodejs_image/buildconfig
-ifdef _build_amd64
-	docker buildx build --progress=plain --platform linux/amd64 $(EXTRA_BUILD_FLAGS) --build-arg REGISTRY=$(REGISTRY) --build-arg ARCH=amd64 -t $(NAME)-nodejs:$(VERSION)-amd64 --rm nodejs_image
-endif
-ifdef _build_arm64
-	docker buildx build --progress=plain --platform linux/arm64 $(EXTRA_BUILD_FLAGS) --build-arg REGISTRY=$(REGISTRY) --build-arg ARCH=arm64 -t $(NAME)-nodejs:$(VERSION)-arm64 --rm nodejs_image
-endif
-
-build_full: build_base
-	rm -rf full_image
-	cp -pR image full_image
-	echo ruby30=1 >> full_image/buildconfig
-	echo ruby31=1 >> full_image/buildconfig
-	echo ruby32=1 >> full_image/buildconfig
-	echo jruby93=1 >> full_image/buildconfig
-	echo jruby94=1 >> full_image/buildconfig
-	echo python=1 >> full_image/buildconfig
-	echo nodejs=1 >> full_image/buildconfig
-	echo redis=1 >> full_image/buildconfig
-	echo memcached=1 >> full_image/buildconfig
-	echo final=1 >> full_image/buildconfig
-ifdef _build_amd64
-	docker buildx build --progress=plain --platform linux/amd64 $(EXTRA_BUILD_FLAGS) --build-arg REGISTRY=$(REGISTRY) --build-arg ARCH=amd64 -t $(NAME)-full:$(VERSION)-amd64 --rm full_image
-endif
-ifdef _build_arm64
-	docker buildx build --progress=plain --platform linux/arm64 $(EXTRA_BUILD_FLAGS) --build-arg REGISTRY=$(REGISTRY) --build-arg ARCH=arm64 -t $(NAME)-full:$(VERSION)-arm64 --rm full_image
-endif
-
-tag_latest: tag_latest_customizable tag_latest_ruby30 tag_latest_ruby31 tag_latest_ruby32 tag_latest_jruby93 tag_latest_jruby94 tag_latest_nodejs tag_latest_full
-
-cross_tag:
-ifdef _build_amd64
-	docker tag ghcr.io/phusion/passenger-customizable:$(VERSION)-amd64 $(NAME)-customizable:$(VERSION)-amd64
-	docker tag ghcr.io/phusion/passenger-ruby30:$(VERSION)-amd64 $(NAME)-ruby30:$(VERSION)-amd64
-	docker tag ghcr.io/phusion/passenger-ruby31:$(VERSION)-amd64 $(NAME)-ruby31:$(VERSION)-amd64
-	docker tag ghcr.io/phusion/passenger-ruby32:$(VERSION)-amd64 $(NAME)-ruby32:$(VERSION)-amd64
-	docker tag ghcr.io/phusion/passenger-jruby93:$(VERSION)-amd64 $(NAME)-jruby93:$(VERSION)-amd64
-	docker tag ghcr.io/phusion/passenger-jruby94:$(VERSION)-amd64 $(NAME)-jruby94:$(VERSION)-amd64
-	docker tag ghcr.io/phusion/passenger-nodejs:$(VERSION)-amd64 $(NAME)-nodejs:$(VERSION)-amd64
-	docker tag ghcr.io/phusion/passenger-full:$(VERSION)-amd64 $(NAME)-full:$(VERSION)-amd64
-endif
-ifdef _build_arm64
-	docker tag ghcr.io/phusion/passenger-customizable:$(VERSION)-arm64 $(NAME)-customizable:$(VERSION)-arm64
-	docker tag ghcr.io/phusion/passenger-ruby30:$(VERSION)-arm64 $(NAME)-ruby30:$(VERSION)-arm64
-	docker tag ghcr.io/phusion/passenger-ruby31:$(VERSION)-arm64 $(NAME)-ruby31:$(VERSION)-arm64
-	docker tag ghcr.io/phusion/passenger-ruby32:$(VERSION)-arm64 $(NAME)-ruby32:$(VERSION)-arm64
-	docker tag ghcr.io/phusion/passenger-jruby93:$(VERSION)-arm64 $(NAME)-jruby93:$(VERSION)-arm64
-	docker tag ghcr.io/phusion/passenger-jruby94:$(VERSION)-arm64 $(NAME)-jruby94:$(VERSION)-arm64
-	docker tag ghcr.io/phusion/passenger-nodejs:$(VERSION)-arm64 $(NAME)-nodejs:$(VERSION)-arm64
-	docker tag ghcr.io/phusion/passenger-full:$(VERSION)-arm64 $(NAME)-full:$(VERSION)-arm64
-endif
-
-tag_latest_customizable:
-ifdef _build_amd64
-	docker tag $(NAME)-customizable:$(VERSION)-amd64 $(NAME)-customizable:latest-amd64
-endif
-ifdef _build_arm64
-	docker tag $(NAME)-customizable:$(VERSION)-arm64 $(NAME)-customizable:latest-arm64
-endif
-
-tag_latest_ruby30:
-ifdef _build_amd64
-	docker tag $(NAME)-ruby30:$(VERSION)-amd64 $(NAME)-ruby30:latest-amd64
-endif
-ifdef _build_arm64
-	docker tag $(NAME)-ruby30:$(VERSION)-arm64 $(NAME)-ruby30:latest-arm64
-endif
-
-tag_latest_ruby31:
-ifdef _build_amd64
-	docker tag $(NAME)-ruby31:$(VERSION)-amd64 $(NAME)-ruby31:latest-amd64
-endif
-ifdef _build_arm64
-	docker tag $(NAME)-ruby31:$(VERSION)-arm64 $(NAME)-ruby31:latest-arm64
-endif
-
-tag_latest_ruby32:
-ifdef _build_amd64
-	docker tag $(NAME)-ruby32:$(VERSION)-amd64 $(NAME)-ruby32:latest-amd64
-endif
-ifdef _build_arm64
-	docker tag $(NAME)-ruby32:$(VERSION)-arm64 $(NAME)-ruby32:latest-arm64
-endif
-
-tag_latest_jruby93:
-ifdef _build_amd64
-	docker tag $(NAME)-jruby93:$(VERSION)-amd64 $(NAME)-jruby93:latest-amd64
-endif
-ifdef _build_arm64
-	docker tag $(NAME)-jruby93:$(VERSION)-arm64 $(NAME)-jruby93:latest-arm64
-endif
-
-tag_latest_jruby94:
-ifdef _build_amd64
-	docker tag $(NAME)-jruby94:$(VERSION)-amd64 $(NAME)-jruby94:latest-amd64
-endif
-ifdef _build_arm64
-	docker tag $(NAME)-jruby94:$(VERSION)-arm64 $(NAME)-jruby94:latest-arm64
-endif
-
-tag_latest_nodejs:
-ifdef _build_amd64
-	docker tag $(NAME)-nodejs:$(VERSION)-amd64 $(NAME)-nodejs:latest-amd64
-endif
-ifdef _build_arm64
-	docker tag $(NAME)-nodejs:$(VERSION)-arm64 $(NAME)-nodejs:latest-arm64
-endif
-
-tag_latest_full:
-ifdef _build_amd64
-	docker tag $(NAME)-full:$(VERSION)-amd64 $(NAME)-full:latest-amd64
-endif
-ifdef _build_arm64
-	docker tag $(NAME)-full:$(VERSION)-arm64 $(NAME)-full:latest-arm64
-endif
-
-push: push_customizable push_ruby30 push_ruby31 push_ruby32 push_jruby93 push_jruby94 push_nodejs push_full
-
-push_customizable: tag_latest_customizable
-ifdef _build_amd64
-	docker push $(NAME)-customizable:latest-amd64
-	docker push $(NAME)-customizable:$(VERSION)-amd64
-endif
-ifdef _build_arm64
-	docker push $(NAME)-customizable:latest-arm64
-	docker push $(NAME)-customizable:$(VERSION)-arm64
-endif
-
-push_ruby30: tag_latest_ruby30
-ifdef _build_amd64
-	docker push $(NAME)-ruby30:latest-amd64
-	docker push $(NAME)-ruby30:$(VERSION)-amd64
-endif
-ifdef _build_arm64
-	docker push $(NAME)-ruby30:latest-arm64
-	docker push $(NAME)-ruby30:$(VERSION)-arm64
-endif
-
-push_ruby31: tag_latest_ruby31
-ifdef _build_amd64
-	docker push $(NAME)-ruby31:latest-amd64
-	docker push $(NAME)-ruby31:$(VERSION)-amd64
-endif
-ifdef _build_arm64
-	docker push $(NAME)-ruby31:latest-arm64
-	docker push $(NAME)-ruby31:$(VERSION)-arm64
-endif
-
-push_ruby32: tag_latest_ruby32
-ifdef _build_amd64
-	docker push $(NAME)-ruby32:latest-amd64
-	docker push $(NAME)-ruby32:$(VERSION)-amd64
-endif
-ifdef _build_arm64
-	docker push $(NAME)-ruby32:latest-arm64
-	docker push $(NAME)-ruby32:$(VERSION)-arm64
-endif
-
-push_jruby93: tag_latest_jruby93
-ifdef _build_amd64
-	docker push $(NAME)-jruby93:latest-amd64
-	docker push $(NAME)-jruby93:$(VERSION)-amd64
-endif
-ifdef _build_arm64
-	docker push $(NAME)-jruby93:latest-arm64
-	docker push $(NAME)-jruby93:$(VERSION)-arm64
-endif
-
-push_jruby94: tag_latest_jruby94
-ifdef _build_amd64
-	docker push $(NAME)-jruby94:latest-amd64
-	docker push $(NAME)-jruby94:$(VERSION)-amd64
-endif
-ifdef _build_arm64
-	docker push $(NAME)-jruby94:latest-arm64
-	docker push $(NAME)-jruby94:$(VERSION)-arm64
-endif
-
-push_nodejs: tag_latest_nodejs
-ifdef _build_amd64
-	docker push $(NAME)-nodejs:latest-amd64
-	docker push $(NAME)-nodejs:$(VERSION)-amd64
-endif
-ifdef _build_arm64
-	docker push $(NAME)-nodejs:latest-arm64
-	docker push $(NAME)-nodejs:$(VERSION)-arm64
-endif
-
-push_full: tag_latest_full
-ifdef _build_amd64
-	docker push $(NAME)-full:latest-amd64
-	docker push $(NAME)-full:$(VERSION)-amd64
-endif
-ifdef _build_arm64
-	docker push $(NAME)-full:latest-arm64
-	docker push $(NAME)-full:$(VERSION)-arm64
-endif
-
-release: release_full release_customizable release_jruby93 release_jruby94 release_nodejs release_ruby32 release_ruby31 release_ruby30
+release: $(foreach image, $(SINGLE_VERSION_IMAGES), release_${image}) $(foreach image, $(SPECIAL_IMAGES), release_${image})
 	test -z "$$(git status --porcelain)" && git commit -am "$(VERSION)" && git tag "rel-$(VERSION)" && git push origin "rel-$(VERSION)"
 
-release_full: push_full
-	docker manifest rm $(NAME)-full:latest || true
-	docker manifest create $(NAME)-full:$(VERSION) $(NAME)-full:$(VERSION)-amd64 $(NAME)-full:$(VERSION)-arm64
-	docker manifest create $(NAME)-full:latest     $(NAME)-full:latest-amd64     $(NAME)-full:latest-arm64
-	docker manifest push $(NAME)-full:$(VERSION)
-	docker manifest push $(NAME)-full:latest
-
-release_customizable: push_customizable
-	docker manifest rm $(NAME)-customizable:latest || true
-	docker manifest create $(NAME)-customizable:$(VERSION) $(NAME)-customizable:$(VERSION)-amd64 $(NAME)-customizable:$(VERSION)-arm64
-	docker manifest create $(NAME)-customizable:latest     $(NAME)-customizable:latest-amd64     $(NAME)-customizable:latest-arm64
-	docker manifest push $(NAME)-customizable:$(VERSION)
-	docker manifest push $(NAME)-customizable:latest
-
-release_jruby93: push_jruby93
-	docker manifest rm $(NAME)-jruby93:latest || true
-	docker manifest create $(NAME)-jruby93:$(VERSION) $(NAME)-jruby93:$(VERSION)-amd64 $(NAME)-jruby93:$(VERSION)-arm64
-	docker manifest create $(NAME)-jruby93:latest	  $(NAME)-jruby93:latest-amd64	   $(NAME)-jruby93:latest-arm64
-	docker manifest push $(NAME)-jruby93:$(VERSION)
-	docker manifest push $(NAME)-jruby93:latest
-
-release_jruby94: push_jruby94
-	docker manifest rm $(NAME)-jruby94:latest || true
-	docker manifest create $(NAME)-jruby94:$(VERSION) $(NAME)-jruby94:$(VERSION)-amd64 $(NAME)-jruby94:$(VERSION)-arm64
-	docker manifest create $(NAME)-jruby94:latest	  $(NAME)-jruby94:latest-amd64	   $(NAME)-jruby94:latest-arm64
-	docker manifest push $(NAME)-jruby94:$(VERSION)
-	docker manifest push $(NAME)-jruby94:latest
-
-release_nodejs: push_nodejs
-	docker manifest rm $(NAME)-nodejs:latest || true
-	docker manifest create $(NAME)-nodejs:$(VERSION) $(NAME)-nodejs:$(VERSION)-amd64 $(NAME)-nodejs:$(VERSION)-arm64
-	docker manifest create $(NAME)-nodejs:latest	 $(NAME)-nodejs:latest-amd64	 $(NAME)-nodejs:latest-arm64
-	docker manifest push $(NAME)-nodejs:$(VERSION)
-	docker manifest push $(NAME)-nodejs:latest
-
-release_ruby32: push_ruby32
-	docker manifest rm $(NAME)-ruby32:latest || true
-	docker manifest create $(NAME)-ruby32:$(VERSION) $(NAME)-ruby32:$(VERSION)-amd64 $(NAME)-ruby32:$(VERSION)-arm64
-	docker manifest create $(NAME)-ruby32:latest	 $(NAME)-ruby32:latest-amd64	 $(NAME)-ruby32:latest-arm64
-	docker manifest push $(NAME)-ruby32:$(VERSION)
-	docker manifest push $(NAME)-ruby32:latest
-
-release_ruby31: push_ruby31
-	docker manifest rm $(NAME)-ruby31:latest || true
-	docker manifest create $(NAME)-ruby31:$(VERSION) $(NAME)-ruby31:$(VERSION)-amd64 $(NAME)-ruby31:$(VERSION)-arm64
-	docker manifest create $(NAME)-ruby31:latest	 $(NAME)-ruby31:latest-amd64	 $(NAME)-ruby31:latest-arm64
-	docker manifest push $(NAME)-ruby31:$(VERSION)
-	docker manifest push $(NAME)-ruby31:latest
-
-release_ruby30: push_ruby30
-	docker manifest rm $(NAME)-ruby30:latest || true
-	docker manifest create $(NAME)-ruby30:$(VERSION) $(NAME)-ruby30:$(VERSION)-amd64 $(NAME)-ruby30:$(VERSION)-arm64
-	docker manifest create $(NAME)-ruby30:latest	 $(NAME)-ruby30:latest-amd64	 $(NAME)-ruby30:latest-arm64
-	docker manifest push $(NAME)-ruby30:$(VERSION)
-	docker manifest push $(NAME)-ruby30:latest
+release_%: push_%
+	docker manifest rm $(NAME)-$*:latest || true
+	docker manifest create $(NAME)-$*:$(VERSION) $(NAME)-$*:$(VERSION)-amd64 $(NAME)-$*:$(VERSION)-arm64
+	docker manifest create $(NAME)-$*:latest     $(NAME)-$*:latest-amd64     $(NAME)-$*:latest-arm64
+	docker manifest push $(NAME)-$*:$(VERSION)
+	docker manifest push $(NAME)-$*:latest
 
 clean:
-	rm -rf base_image
-	rm -rf customizable_image
-	rm -rf ruby30_image
-	rm -rf ruby31_image
-	rm -rf ruby32_image
-	rm -rf jruby93_image
-	rm -rf jruby94_image
-	rm -rf nodejs_image
-	rm -rf full_image
+	rm -rf *_image
 
-clean_images:
-	docker rmi $(NAME)-customizable:latest-amd64 $(NAME)-customizable:$(VERSION)-amd64 || true
-	docker rmi $(NAME)-customizable:latest-arm64 $(NAME)-customizable:$(VERSION)-arm64 || true
-	docker rmi $(NAME)-ruby30:latest-amd64 $(NAME)-ruby30:$(VERSION)-amd64 || true
-	docker rmi $(NAME)-ruby30:latest-arm64 $(NAME)-ruby30:$(VERSION)-arm64 || true
-	docker rmi $(NAME)-ruby31:latest-amd64 $(NAME)-ruby31:$(VERSION)-amd64 || true
-	docker rmi $(NAME)-ruby31:latest-arm64 $(NAME)-ruby31:$(VERSION)-arm64 || true
-	docker rmi $(NAME)-ruby32:latest-amd64 $(NAME)-ruby32:$(VERSION)-amd64 || true
-	docker rmi $(NAME)-ruby32:latest-arm64 $(NAME)-ruby32:$(VERSION)-arm64 || true
-	docker rmi $(NAME)-jruby93:latest-amd64 $(NAME)-jruby93:$(VERSION)-amd64 || true
-	docker rmi $(NAME)-jruby93:latest-arm64 $(NAME)-jruby93:$(VERSION)-arm64 || true
-	docker rmi $(NAME)-jruby94:latest-amd64 $(NAME)-jruby94:$(VERSION)-amd64 || true
-	docker rmi $(NAME)-jruby94:latest-arm64 $(NAME)-jruby94:$(VERSION)-arm64 || true
-	docker rmi $(NAME)-nodejs:latest-amd64 $(NAME)-nodejs:$(VERSION)-amd64 || true
-	docker rmi $(NAME)-nodejs:latest-arm64 $(NAME)-nodejs:$(VERSION)-arm64 || true
-	docker rmi $(NAME)-full:latest-amd64 $(NAME)-full:$(VERSION)-amd64 || true
-	docker rmi $(NAME)-full:latest-arm64 $(NAME)-full:$(VERSION)-arm64 || true
-	docker rmi $(NAME)-base:current-amd64 || true
-	docker rmi $(NAME)-base:current-arm64 || true
+clean_images: $(foreach image, $(SINGLE_VERSION_IMAGES), clean_image_${image}) $(foreach image, $(SPECIAL_IMAGES), clean_image_${image}) FORCE
+	docker rmi $(REGISTRY)/phusion/passenger-base:current-amd64 phusion/passenger-base:current-amd64 || true
+	docker rmi $(REGISTRY)/phusion/passenger-base:current-arm64 phusion/passenger-base:current-arm64 || true
+
+clean_image_%: FORCE
+	docker rmi $(NAME)-$*:latest-amd64 $(NAME)-$*:$(VERSION)-amd64 || true
+	docker rmi $(NAME)-$*:latest-arm64 $(NAME)-$*:$(VERSION)-arm64 || true

--- a/Makefile
+++ b/Makefile
@@ -34,8 +34,10 @@ endif
 
 FORCE:
 
-SPECIAL_IMAGES:= customizable full
+SPECIAL_IMAGES := customizable full
 SINGLE_VERSION_IMAGES := jruby93 jruby94 nodejs ruby30 ruby31 ruby32
+
+ALL_IMAGES := $(SPECIAL_IMAGES) $(SINGLE_VERSION_IMAGES)
 
 all: build_all
 
@@ -82,7 +84,7 @@ ifdef _build_arm64
 	docker buildx build --progress=plain --platform linux/arm64 $(EXTRA_BUILD_FLAGS) --build-arg REGISTRY=$(REGISTRY) --build-arg ARCH=arm64 -t $(NAME)-$*:$(VERSION)-arm64 --rm $*_image
 endif
 
-labels: $(foreach image, $(SINGLE_VERSION_IMAGES), label_${image}) $(foreach image, $(SPECIAL_IMAGES), label_${image})
+labels: $(foreach image, $(ALL_IMAGES), label_${image})
 
 label_%: FORCE
 ifdef _build_amd64
@@ -92,7 +94,7 @@ ifdef _build_arm64
 	@echo $(NAME)-$*:$(VERSION)-arm64 $(NAME)-$*:latest-arm64
 endif
 
-pull: $(foreach image, $(SINGLE_VERSION_IMAGES), pull_${image}) $(foreach image, $(SPECIAL_IMAGES), pull_${image})
+pull: $(foreach image, $(ALL_IMAGES), pull_${image})
 
 pull_%: FORCE
 ifdef _build_amd64
@@ -102,7 +104,7 @@ ifdef _build_arm64
 	docker pull $(NAME)-$*:$(VERSION)-arm64
 endif
 
-cross_tag: $(foreach image, $(SINGLE_VERSION_IMAGES), cross_tag_${image}) $(foreach image, $(SPECIAL_IMAGES), cross_tag_${image})
+cross_tag: $(foreach image, $(ALL_IMAGES), cross_tag_${image})
 
 cross_tag_%: FORCE
 ifdef _build_amd64
@@ -112,7 +114,7 @@ ifdef _build_arm64
 	docker tag ghcr.io/phusion/passenger-$*:$(VERSION)-arm64 $(NAME)-$*:$(VERSION)-arm64
 endif
 
-tag_latest: $(foreach image, $(SINGLE_VERSION_IMAGES), tag_latest_${image}) $(foreach image, $(SPECIAL_IMAGES), tag_latest_${image})
+tag_latest: $(foreach image, $(ALL_IMAGES), tag_latest_${image})
 
 tag_latest_%: FORCE
 ifdef _build_amd64
@@ -122,7 +124,7 @@ ifdef _build_arm64
 	docker tag $(NAME)-$*:$(VERSION)-arm64 $(NAME)-$*:latest-arm64
 endif
 
-push: $(foreach image, $(SINGLE_VERSION_IMAGES), push_${image}) $(foreach image, $(SPECIAL_IMAGES), push_${image})
+push: $(foreach image, $(ALL_IMAGES), push_${image})
 
 push_%: tag_latest_%
 ifdef _build_amd64
@@ -134,7 +136,7 @@ ifdef _build_arm64
 	docker push $(NAME)-$*:$(VERSION)-arm64
 endif
 
-release: $(foreach image, $(SINGLE_VERSION_IMAGES), release_${image}) $(foreach image, $(SPECIAL_IMAGES), release_${image})
+release: $(foreach image, $(ALL_IMAGES), release_${image})
 	test -z "$$(git status --porcelain)" && git commit -am "$(VERSION)" && git tag "rel-$(VERSION)" && git push origin "rel-$(VERSION)"
 
 release_%: push_%
@@ -147,7 +149,7 @@ release_%: push_%
 clean:
 	rm -rf *_image
 
-clean_images: $(foreach image, $(SINGLE_VERSION_IMAGES), clean_image_${image}) $(foreach image, $(SPECIAL_IMAGES), clean_image_${image}) FORCE
+clean_images: $(foreach image, $(ALL_IMAGES), clean_image_${image}) FORCE
 	docker rmi $(REGISTRY)/phusion/passenger-base:current-amd64 phusion/passenger-base:current-amd64 || true
 	docker rmi $(REGISTRY)/phusion/passenger-base:current-arm64 phusion/passenger-base:current-arm64 || true
 

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ ALL_IMAGES := $(SPECIAL_IMAGES) $(SINGLE_VERSION_IMAGES)
 
 all: build_all
 
-# waits are to ensure that we only compile each version of ruby once per arch when even if running parallel
+# waits are to ensure that we only compile each version of ruby once per arch even if running parallel
 build_all: \
 	build_customizable \
 	.WAIT \


### PR DESCRIPTION
This does not change the default behaviour of make.

1) Substantially reduces the size of the Makefile with macros.

2) Allows overriding VERSION and NAME during build to easily build, tag, and upload to a custom repository, without editing the Makefile or manually creating tags after build.

3) Allows building for only a single architecture without editing the Makefile .

Adds support for the following environment variables during make:

VERSION (if set, this overrides the VERSION set in Makefile)
NAME (if set, this overrides the repository and image base name set in Makefile)
BUILD_AMD64 (if this exists and is set to 0, the amd64 images will not be built)
BUILD_ARM64 (if this exists and is set to 0, the arm64 images will not be built)

... make sure these are not set in your environment if you don't want to change the default behaviour of make.

example build with this Makefile:

VERSION=2.6.0.1 BUILD_ARM64=0 NAME="MYAWSACCOUNT.dkr.ecr.us-west-2.amazonaws.com/passenger" make -j1 build_customizable  build_ruby32 push_customizable push_ruby32
