### PR TITLE
Use SIGQUIT instead of SIGTERM to shutdown nginx.

### DIFF
--- a/image/nginx-passenger.sh
+++ b/image/nginx-passenger.sh
@@ -48,6 +48,10 @@ run touch /etc/service/nginx/down
 run mkdir /etc/service/nginx-log-forwarder
 run cp /pd_build/runit/nginx-log-forwarder /etc/service/nginx-log-forwarder/run
 
+## Use SIGQUIT instead of SIGTERM to shutdown nginx
+run mkdir -p /etc/service/nginx/control/
+run cp /pd_build/runit/nginx-term /etc/service/nginx/control/t
+
 run mkdir /var/run/passenger-instreg
 
 run sed -i 's|invoke-rc.d nginx rotate|sv 1 nginx|' /etc/logrotate.d/nginx

--- a/image/runit/nginx-term
+++ b/image/runit/nginx-term
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+
+sv q nginx


### PR DESCRIPTION
Modifies the default signal sent to nginx when terminating the container to allow graceful exit.

Closes https://github.com/phusion/passenger-docker/issues/149