### PR TITLE
Explicitly install "file"

### DIFF
--- a/image/utilities.sh
+++ b/image/utilities.sh
@@ -10,3 +10,6 @@ run minimal_apt_get_install git
 run minimal_apt_get_install netbase
 ## utilities needed to add apt ppas
 run minimal_apt_get_install curl gnupg ca-certificates
+## almost everyone needs file, and it sort of randomly gets pulled in during
+## the build process anyway
+run minimal_apt_get_install file


### PR DESCRIPTION
This fixes a bug that doesn't affect the official build images, but did bite me building the images locally.

Basically, "file" isn't in baseimage, but does get pulled in by some development tools. If the image being built doesn't need those because of caching, then file doesn't end up being in the end image.

All this does is explicitly install file, which is present in all current official build images anyway.