### PR TITLE
Add a Python 3.13 image

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,6 +31,7 @@ jobs:
          - ruby32 # EOL: 2026-03-31
          - ruby31 # EOL: 2025-03-31
          # https://www.ruby-lang.org/en/downloads/branches/
+         - python313 # EOL: 2029-10-07
          - python312 # EOL: 2028-10-02
          - python311 # EOL: 2027-10-24
          - python310 # EOL: 2026-10-04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 3.0.8 (release date: TBD)
  * Upgraded to Ruby 3.3.5
+ * Added a Python 3.13 image
 
 ## 3.0.7 (release date: 2024-07-30)
  * Upgraded to Ruby 3.3.4

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ FORCE:
 # when adding a cRuby image, also update image/nginx-passenger.sh and image/ruby-support/finalize.sh
 SPECIAL_IMAGES := customizable full
 CRUBY_IMAGES := ruby31 ruby32 ruby33
-PYTHON_IMAGES := python38 python39 python310 python311 python312
+PYTHON_IMAGES := python38 python39 python310 python311 python312 python313
 MISC_IMAGES := jruby93 jruby94 nodejs
 
 ALL_IMAGES := $(SPECIAL_IMAGES) $(MISC_IMAGES) $(CRUBY_IMAGES) $(PYTHON_IMAGES)

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Language support:
    * 3.3.5 is configured as the default.
    * JRuby is installed from source, but we register an APT entry for it.
    * JRuby uses OpenJDK 17.
- * Python 2.7 or 3.10, or any version provided by the Deadsnakes PPA (currently 3.7, 3.8, 3.9, 3.11, and 3.12; see https://launchpad.net/~deadsnakes/+archive/ubuntu/ppa).
+ * Python 2.7 or 3.10, or any version provided by the Deadsnakes PPA (currently 3.7, 3.8, 3.9, 3.11, 3.12, and 3.13; see https://launchpad.net/~deadsnakes/+archive/ubuntu/ppa).
  * Node.js 18 by default, or any version provided by Nodesource (currently 16, 18, 20, 21; see https://github.com/nodesource/distributions).
  * A build system, git, and development headers for many popular libraries, so that the most popular Ruby, Python and Node.js native extensions can be compiled without problems.
 
@@ -142,6 +142,7 @@ Python images
  * `phusion/passenger-python310` - Python 3.10
  * `phusion/passenger-python311` - Python 3.11
  * `phusion/passenger-python312` - Python 3.12
+ * `phusion/passenger-python312` - Python 3.13
 
 **Node.js and Meteor images**
 


### PR DESCRIPTION
Python 3.13.0 has been released. This adds a versioned image for it.