### PR TITLE
Add a Ruby 3.4 image

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,6 +27,7 @@ jobs:
          - jruby94
          - jruby93
          # - ruby34 # REL: 2024-12-25
+         - ruby34 # EOL: 2028-03-31
          - ruby33 # EOL: 2027-03-31
          - ruby32 # EOL: 2026-03-31
          - ruby31 # EOL: 2025-03-31

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.1.1 (not released)
+ * Added a Ruby 3.4 image (Ruby 3.4.1)
+ * Default Ruby version is now 3.4.1
+
 ## 3.1.0 (release date: 2024-12-09)
  * Upgraded image base to phusion/baseimage:noble-1.0.0
    * Upgraded to Ubuntu 24.04 LTS (Noble)

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ FORCE:
 
 # when adding a cRuby image, also update image/nginx-passenger.sh and image/ruby-support/finalize.sh
 SPECIAL_IMAGES := customizable full
-CRUBY_IMAGES := ruby31 ruby32 ruby33
+CRUBY_IMAGES := ruby31 ruby32 ruby33 ruby34
 PYTHON_IMAGES := python39 python310 python311 python312 python313
 MISC_IMAGES := jruby93 jruby94 nodejs
 

--- a/Makefile
+++ b/Makefile
@@ -90,10 +90,10 @@ build_%: build_base
 	    echo final=1 >> ${*}_image/buildconfig; \
 	fi
 ifeq ($(_build_amd64),1)
-	docker buildx build --progress=plain --platform linux/amd64 $(EXTRA_BUILD_FLAGS) --build-arg REGISTRY=$(REGISTRY) --build-arg ARCH=amd64 -t $(NAME)-$*:$(VERSION)-amd64 --rm $*_image
+	docker buildx build --progress=plain --platform linux/amd64 $(EXTRA_BUILD_FLAGS) --build-arg NAME=$(NAME) --build-arg ARCH=amd64 -t $(NAME)-$*:$(VERSION)-amd64 --rm $*_image
 endif
 ifeq ($(_build_arm64),1)
-	docker buildx build --progress=plain --platform linux/arm64 $(EXTRA_BUILD_FLAGS) --build-arg REGISTRY=$(REGISTRY) --build-arg ARCH=arm64 -t $(NAME)-$*:$(VERSION)-arm64 --rm $*_image
+	docker buildx build --progress=plain --platform linux/arm64 $(EXTRA_BUILD_FLAGS) --build-arg NAME=$(NAME) --build-arg ARCH=arm64 -t $(NAME)-$*:$(VERSION)-arm64 --rm $*_image
 endif
 
 labels: $(foreach image, $(ALL_IMAGES), label_${image})

--- a/README.md
+++ b/README.md
@@ -94,9 +94,9 @@ Basics (learn more at [baseimage-docker](http://phusion.github.io/baseimage-dock
 
 Language support:
 
- * Ruby 3.1.6, 3.2.6, 3.3.6 and JRuby 9.3.15.0 and 9.4.8.0.
+ * Ruby 3.1.6, 3.2.6, 3.3.6, 3.4.1 and JRuby 9.3.15.0 and 9.4.8.0.
    * RVM is used to manage Ruby versions. [Why RVM?](#why_rvm)
-   * 3.3.6 is configured as the default.
+   * 3.4.1 is configured as the default.
    * JRuby is installed from source, but we register an APT entry for it.
    * JRuby uses OpenJDK 17.
  * Python 3.12, or any version provided by the Deadsnakes PPA (currently 3.8, 3.9, 3.10, and 3.11; see https://launchpad.net/~deadsnakes/+archive/ubuntu/ppa).
@@ -132,6 +132,7 @@ Passenger-docker consists of several images, each one tailor made for a specific
  * `phusion/passenger-ruby31` - Ruby 3.1.
  * `phusion/passenger-ruby32` - Ruby 3.2.
  * `phusion/passenger-ruby33` - Ruby 3.3.
+ * `phusion/passenger-ruby34` - Ruby 3.4.
  * `phusion/passenger-jruby93` - JRuby 9.3.
  * `phusion/passenger-jruby94` - JRuby 9.4.
 
@@ -183,6 +184,7 @@ FROM phusion/passenger-full:<VERSION>
 #FROM phusion/passenger-ruby31:<VERSION>
 #FROM phusion/passenger-ruby32:<VERSION>
 #FROM phusion/passenger-ruby33:<VERSION>
+#FROM phusion/passenger-ruby34:<VERSION>
 #FROM phusion/passenger-python39:<VERSION>
 #FROM phusion/passenger-python310:<VERSION>
 #FROM phusion/passenger-python311:<VERSION>
@@ -215,6 +217,7 @@ CMD ["/sbin/my_init"]
 #RUN /pd_build/ruby-3.1.*.sh
 #RUN /pd_build/ruby-3.2.*.sh
 #RUN /pd_build/ruby-3.3.*.sh
+#RUN /pd_build/ruby-3.4.*.sh
 #RUN /pd_build/jruby-9.3.*.sh
 #RUN /pd_build/jruby-9.4.*.sh
 #
@@ -271,6 +274,8 @@ server {
     passenger_user app;
 
     # If this is a Ruby app, specify a Ruby version:
+    # For Ruby 3.4
+    passenger_ruby /usr/bin/ruby3.4;
     # For Ruby 3.3
     passenger_ruby /usr/bin/ruby3.3;
     # For Ruby 3.2
@@ -453,6 +458,8 @@ RUN bash -lc 'rvm --default use ruby-3.1.6'
 RUN bash -lc 'rvm --default use ruby-3.2.6'
 # Ruby 3.3.6
 RUN bash -lc 'rvm --default use ruby-3.3.6'
+# Ruby 3.4.1
+RUN bash -lc 'rvm --default use ruby-3.4.1'
 # JRuby 9.3.15.0
 RUN bash -lc 'rvm --default use jruby-9.3.15.0'
 # JRuby 9.4.8.0
@@ -467,20 +474,20 @@ Learn more: [RVM: Setting the default Ruby](https://rvm.io/rubies/default).
 You can run any command with a specific Ruby version by prefixing it with `rvm-exec <IDENTIFIER>`. For example:
 
 ```bash
-$ rvm-exec 3.1.6 ruby -v
-Using /usr/local/rvm/gems/ruby-3.1.6
-ruby 3.1.6p260 (2024-05-29 revision a777087be6) [x86_64-linux]
-
 $ rvm-exec 3.3.6 ruby -v
 Using /usr/local/rvm/gems/ruby-3.3.6
 ruby 3.3.6 (2024-11-05 revision 75015d4c1f) [x86_64-linux]
+
+$ rvm-exec 3.4.1 ruby -v
+Using /usr/local/rvm/gems/ruby-3.4.1
+ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [x86_64-linux]
 ```
 
 More examples, but with Bundler instead:
 
 ```bash
-# This runs 'bundle install' using Ruby 3.3.6
-rvm-exec 3.3.6 bundle install
+# This runs 'bundle install' using Ruby 3.4.1
+rvm-exec 3.4.1 bundle install
 ```
 
 <a name="default_ruby_wrapper_scripts"></a>
@@ -843,6 +850,7 @@ Build one of the images:
     make build_ruby31
     make build_ruby32
     make build_ruby33
+    make build_ruby34
     make build_python39
     make build_python310
     make build_python311

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.2
 ARG ARCH
-ARG REGISTRY
-FROM $REGISTRY/phusion/passenger-base:current-$ARCH
+ARG NAME
+FROM $NAME-base:current-$ARCH
 MAINTAINER Phusion <info@phusion.nl>
 
 ADD . /pd_build

--- a/image/nginx-passenger.sh
+++ b/image/nginx-passenger.sh
@@ -9,7 +9,7 @@ header "Installing Phusion Passenger..."
 ## Install it through RVM, not APT, so that the -customizable variant cannot end up
 ## having Ruby installed from both APT and RVM.
 if [[ ! -e /usr/bin/ruby ]]; then
-	RVM_ID="ruby-3.3.6"
+	RVM_ID="ruby-3.4.1"
 
 	run mkdir -p "/build_cache/${ARCH}"
 	if [[ -e "/build_cache/${ARCH}/${RVM_ID}.tar.bz2" ]]; then
@@ -59,6 +59,10 @@ run sed -i -e '/sv 1 nginx.*/a\' -e '		passenger-config reopen-logs >/dev/null 2
 run rm -f /var/log/nginx/error.log
 
 ## Precompile Ruby extensions.
+if [[ -e /usr/bin/ruby3.4 ]]; then
+	run ruby3.4 -S passenger-config build-native-support
+	run setuser app ruby3.4 -S passenger-config build-native-support
+fi
 if [[ -e /usr/bin/ruby3.3 ]]; then
 	run ruby3.3 -S passenger-config build-native-support
 	run setuser app ruby3.3 -S passenger-config build-native-support

--- a/image/ruby-3.4.1.sh
+++ b/image/ruby-3.4.1.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -e
+source /pd_build/buildconfig
+
+RVM_ID=$(basename "$0" | sed 's/.sh$//')
+
+header "Installing $RVM_ID"
+
+run mkdir -p "/build_cache/${ARCH}"
+if [[ -e "/build_cache/${ARCH}/${RVM_ID}.tar.bz2" ]]; then
+	# use cached ruby if present
+	run /usr/local/rvm/bin/rvm mount "/build_cache/${ARCH}/${RVM_ID}.tar.bz2"
+else
+	# otherwise build one
+	run minimal_apt_get_install rustc # For compiling Ruby with YJIT
+	MAKEFLAGS=-j$(nproc) run /usr/local/rvm/bin/rvm install $RVM_ID --disable-cache || ( cat /usr/local/rvm/log/*${RVM_ID}*/*.log && false )
+	run cd "/build_cache/${ARCH}"
+	run /usr/local/rvm/bin/rvm prepare "${RVM_ID}"
+	run cd /
+fi
+
+run /usr/local/rvm/bin/rvm-exec $RVM_ID@global gem install $DEFAULT_RUBY_GEMS --no-document
+# Make passenger_system_ruby work.
+run create_rvm_wrapper_script ruby3.4 $RVM_ID ruby
+run /pd_build/ruby_support/install_ruby_utils.sh
+run /pd_build/ruby_support/finalize.sh

--- a/image/ruby_support/finalize.sh
+++ b/image/ruby_support/finalize.sh
@@ -24,7 +24,9 @@ function set_rvm_default()
 }
 
 # descending order is important, with jruby last
-if [[ "$known_rubies" =~ ruby-3\.3 ]]; then
+if [[ "$known_rubies" =~ ruby-3\.4 ]]; then
+	set_rvm_default ruby-3\.4
+elif [[ "$known_rubies" =~ ruby-3\.3 ]]; then
 	set_rvm_default ruby-3\.3
 elif [[ "$known_rubies" =~ ruby-3\.2 ]]; then
 	set_rvm_default ruby-3\.2


### PR DESCRIPTION
Adds a Ruby 3.4 image (using ruby 3.4.1) and uses Ruby 3.4 by default in passenger-full and non-ruby images.