### PR TITLE
Minor doc and Makefile updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,9 @@ else
 _build_arm64 := 1
 endif
 
+# test if we're running in an interactive shell (vs gh actions)
+INTERACTIVE:=$(shell [ -t 0 ] && echo 1)
+
 .PHONY: all build_base build_all tag_latest cross_tag push release labels clean clean_images
 
 FORCE:
@@ -82,6 +85,9 @@ ifeq ($(_build_arm64),1)
 endif
 
 build_%:
+ifeq ($(INTERACTIVE),1)
+build_%: build_base
+endif
 	rm -rf $*_image
 	cp -pR image $*_image
 	@if [ "${*}" != "full" ] && [ "${*}" != "customizable" ]; then \

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Basics (learn more at [baseimage-docker](http://phusion.github.io/baseimage-dock
 
 Language support:
 
- * Ruby 3.1.6, 3.2.6, 3.3.6, 3.4.1 and JRuby 9.3.15.0 and 9.4.8.0.
+ * Ruby 3.1.6, 3.2.6, 3.3.6, 3.4.1 and JRuby 9.3.15.0 and 9.4.9.0.
    * RVM is used to manage Ruby versions. [Why RVM?](#why_rvm)
    * 3.4.1 is configured as the default.
    * JRuby is installed from source, but we register an APT entry for it.
@@ -462,8 +462,8 @@ RUN bash -lc 'rvm --default use ruby-3.3.6'
 RUN bash -lc 'rvm --default use ruby-3.4.1'
 # JRuby 9.3.15.0
 RUN bash -lc 'rvm --default use jruby-9.3.15.0'
-# JRuby 9.4.8.0
-RUN bash -lc 'rvm --default use jruby-9.4.8.0'
+# JRuby 9.4.9.0
+RUN bash -lc 'rvm --default use jruby-9.4.9.0'
 ```
 
 Learn more: [RVM: Setting the default Ruby](https://rvm.io/rubies/default).


### PR DESCRIPTION
Update docs for recent JRuby update.

Minor update to Makefile to include build_base dependency on build_% when run in an interactive shell. This is needed for local builds. I don't have a good way to test this in Github actions, but I did run it under cron and it appeared to work. Please test that I didn't break your Github speedups.