### PR TITLE
Bugfix in log output for file `timestamp-debug-0.log` on `npm update failure`

### DIFF
--- a/image/nodejs.sh
+++ b/image/nodejs.sh
@@ -17,7 +17,7 @@ if ( ! egrep -q nodesource.gpg /etc/apt/sources.list.d/nodesource.list ); then
 	minimal_apt_get_install nodejs
 
 	echo "+ Updating npm"
-	run npm update npm -g || ( cat /root/.npm/_logs/*-debug.log && false )
+	run npm update npm -g || ( cat /root/.npm/_logs/*-debug*.log && false )
 	if [[ ! -e /usr/bin/node ]]; then
 		ln -s /usr/bin/nodejs /usr/bin/node
 	fi


### PR DESCRIPTION
When using the most recent `phusion/passenger-customizable` (`3.1.6`) and installing node.js v22, the build fails with the following error:

```
9.468 + Updating npm
9.468 + npm update npm -g
9.468 + echo '+ Updating npm'
9.468 + run npm update npm -g
9.468 + echo '+ npm' update npm -g
9.468 + npm update npm -g
11.81 npm error code MODULE_NOT_FOUND
11.81 npm error Cannot find module 'promise-retry'
11.81 npm error Require stack:
11.81 npm error - /usr/lib/node_modules/npm/node_modules/@npmcli/arborist/lib/arborist/rebuild.js
11.81 npm error - /usr/lib/node_modules/npm/node_modules/@npmcli/arborist/lib/arborist/index.js
11.81 npm error - /usr/lib/node_modules/npm/node_modules/@npmcli/arborist/lib/index.js
11.81 npm error - /usr/lib/node_modules/npm/node_modules/libnpmfund/lib/index.js
11.81 npm error - /usr/lib/node_modules/npm/lib/utils/reify-output.js
11.81 npm error - /usr/lib/node_modules/npm/lib/utils/reify-finish.js
11.81 npm error - /usr/lib/node_modules/npm/lib/commands/update.js
11.81 npm error - /usr/lib/node_modules/npm/lib/npm.js
11.81 npm error - /usr/lib/node_modules/npm/lib/cli/entry.js
11.81 npm error - /usr/lib/node_modules/npm/lib/cli.js
11.81 npm error - /usr/lib/node_modules/npm/bin/npm-cli.js
11.81 npm error A complete log of this run can be found in: /root/.npm/_logs/2026-04-02T14_26_53_527Z-debug-0.log
11.82 + cat '/root/.npm/_logs/*-debug.log'
11.82 cat: '/root/.npm/_logs/*-debug.log': No such file or directory
```

The npm error (`Cannot find module 'promise-retry'`) is reported and being tracked in nodejs/node#62425 and npm/cli#9151. 

However, when `npm update npm` fails, a log file is written to `/root/.npm/_logs` named `timestamp-debug-0.log`. The `cat` command in the `nodejs.sh` script fails to find this file due to the `-0` at the end of the name. This error fails the script and subsequently the build.

Dockerfile to reproduce:
```Dockerfile
FROM phusion/passenger-customizable:3.1.6

# Set correct environment variables.
ENV HOME /root

# Use baseimage-docker's init process.
CMD ["/sbin/my_init"]

RUN /pd_build/nodejs.sh 22
```

maintainers, would you mind merging this PR to fix the error in `nodejs.sh` script?