### PR TITLE
Fix a dependency problem introduced in recent Node 22 updates

### DIFF
--- a/image/nodejs.sh
+++ b/image/nodejs.sh
@@ -17,6 +17,11 @@ if ( ! egrep -q nodesource.gpg /etc/apt/sources.list.d/nodesource.list ); then
 	minimal_apt_get_install nodejs
 
 	echo "+ Updating npm"
+	run npm i -g npm@^10 || ( cat /root/.npm/_logs/*-debug*.log && false )
+	run npm i -g npm@~11.10 || ( cat /root/.npm/_logs/*-debug*.log && false )
+	run npm i -g npm@~11.11 || ( cat /root/.npm/_logs/*-debug*.log && false )
+	run npm i -g npm@~11.12 || ( cat /root/.npm/_logs/*-debug*.log && false )
+	run npm i -g npm@latest || ( cat /root/.npm/_logs/*-debug*.log && false )
 	run npm update npm -g || ( cat /root/.npm/_logs/*-debug*.log && false )
 	if [[ ! -e /usr/bin/node ]]; then
 		ln -s /usr/bin/nodejs /usr/bin/node


### PR DESCRIPTION
Fixes a dependency problem introduced in recent Node 22 updates that causes a MODULE_NOT_FOUND error with promise-retry when directly running npm install -g npm@latest

Refs https://github.com/nodejs/node/issues/62425#event-24324799580

[skip ci]