### PR TITLE
Update default ruby to 4.0.5 (from 4.0.2)

### DIFF
--- a/image/nginx-passenger.sh
+++ b/image/nginx-passenger.sh
@@ -9,7 +9,7 @@ header "Installing Phusion Passenger..."
 ## Install it through RVM, not APT, so that the -customizable variant cannot end up
 ## having Ruby installed from both APT and RVM.
 if [[ ! -e /usr/bin/ruby ]]; then
-	RVM_ID="ruby-4.0.2"
+	RVM_ID="ruby-4.0.5"
 
 	run mkdir -p "/build_cache/${ARCH}"
 	if [[ -e "/build_cache/${ARCH}/${RVM_ID}.tar.bz2" ]]; then


### PR DESCRIPTION
The default ruby version appears to not have been updated in a previous commit, this bumps it to 4.0.5.

[skip ci]