### PR TITLE
Update baseimage to resolute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
    * Default Python version is now 3.14 (from 3.12)
    * Nginx version is now 1.28 (from 1.24)
        - changelog can be found at https://nginx.org/en/CHANGES-1.28
+ * Redis now logs to STDOUT by default
 
 ## 3.1.11 (release date: 2026-07-20)
  * Upgraded to Ruby 3.4.10 (from 3.4.9)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
-## 3.1.12 (not yet released)
-
+## 3.2.0 (not yet released)
+ * Upgraded image base to phusion/baseimage:resolute-1.0.7
+   * Upgraded to Ubuntu 26.04 LTS (Resolute)
+       - note updated compiler chain and all tools; please test your apps thoroughly
+   * Default Python version is now 3.14 (from 3.12)
+   * Nginx version is now 1.28 (from 1.24)
+       - changelog can be found at https://nginx.org/en/CHANGES-1.28
 
 ## 3.1.11 (release date: 2026-07-20)
  * Upgraded to Ruby 3.4.10 (from 3.4.9)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
    * Nginx version is now 1.28 (from 1.24)
        - changelog can be found at https://nginx.org/en/CHANGES-1.28
  * Redis now logs to STDOUT by default
+ * Nginx-log-forwarder no longer enabled by default, Nginx now logs straight to STDOUT/STDERR
+    - if you wish to restore the previous behaviour of storing nginx logs in the container, please see https://github.com/phusion/passenger-docker#nginx_passenger
+    - if you had already put workarounds in your containers for this, you should remove them (ie. reverse the instructions in https://github.com/phusion/passenger-docker/issues/72#issuecomment-493270957)
 
 ## 3.1.11 (release date: 2026-07-20)
  * Upgraded to Ruby 3.4.10 (from 3.4.9)

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ REGISTRY ?= docker.io
 endif
 
 NAME ?= $(REGISTRY)/phusion/passenger
-VERSION ?= 3.1.11
+VERSION ?= 3.2.0
 
 # NAME and/or VERSION can be overriden during build if you are building locally to push to your own repository
 # example:

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Why use passenger-docker instead of doing everything yourself in Dockerfile?
 
 Basics (learn more at [baseimage-docker](http://phusion.github.io/baseimage-docker/)):
 
- * Ubuntu 24.04 LTS as base system.
+ * Ubuntu 26.04 LTS (Resolute) as base system.
  * A **correct** init process ([learn more](http://blog.phusion.nl/2015/01/20/docker-and-the-pid-1-zombie-reaping-problem/)).
  * Fixes APT incompatibilities with Docker.
  * syslog-ng.
@@ -98,7 +98,7 @@ Language support:
    * RVM is used to manage Ruby versions. [Why RVM?](#why_rvm)
    * 4.0.6 is configured as the default.
    * JRuby uses OpenJDK 17 (9.4) or 21 (10.0).
- * Python 3.12, or any version provided by the Deadsnakes PPA (currently 3.10, 3.11, 3.12, 3.13, 3,14; see https://launchpad.net/~deadsnakes/+archive/ubuntu/ppa).
+ * Python 3.14, or any version provided by the Deadsnakes PPA (currently 3.10, 3.11, 3.12, 3.13; see https://launchpad.net/~deadsnakes/+archive/ubuntu/ppa).
  * Node.js 24 by default, or any version provided by Nodesource (currently 20, 22, 24; see https://github.com/nodesource/distributions).
  * A build system, git, and development headers for many popular libraries, so that the most popular Ruby, Python and Node.js native extensions can be compiled without problems.
 
@@ -523,7 +523,7 @@ The following example shows how you can add a startup script. This script simply
 <a name="upgrading_os"></a>
 ### Upgrading the operating system inside the container
 
-passenger-docker images contain an Ubuntu 24.04 operating system. You may want to update this OS from time to time, for example to pull in the latest security updates. OpenSSL is a notorious example. Vulnerabilities are discovered in OpenSSL on a regular basis, so you should keep OpenSSL up-to-date as much as you can.
+passenger-docker images contain an Ubuntu 26.04 operating system. You may want to update this OS from time to time, for example to pull in the latest security updates. OpenSSL is a notorious example. Vulnerabilities are discovered in OpenSSL on a regular basis, so you should keep OpenSSL up-to-date as much as you can.
 
 While we release passenger-docker images with the latest OS updates from time to time, you do not have to rely on us. You can update the OS inside passenger-docker images yourself, and it is recommend that you do this instead of waiting for us. This is also especially important to upgrade any installed Python or Node packages to the latest minor version.
 

--- a/README.md
+++ b/README.md
@@ -246,6 +246,15 @@ Nginx and Passenger are disabled by default. Enable them like so:
 RUN rm -f /etc/service/nginx/down
 ```
 
+Nginx logs are sent to STDOUT by default. If you wish to restore this container's legacy behaviour of storing logs in the container and forwarding the nginx error log only to STDOUT, do:
+
+```dockerfile
+RUN rm -f /etc/service/nginx-log-forwarder/down && \
+    sed -i "s/# sv restart/sv restart/" /etc/service/nginx/run && \
+    rm -f /var/log/nginx/access.log /var/log/nginx/error.log && \
+    touch /var/log/nginx/access.log /var/log/nginx/error.log
+```
+
 <a name="adding_web_app"></a>
 #### Adding your web app to the image
 
@@ -804,9 +813,9 @@ If you use Passenger to deploy your web app, run:
 
 If anything goes wrong, consult the log files in /var/log. The following log files are especially important:
 
- * /var/log/nginx/error.log
  * /var/log/syslog
  * Your app's log file in /home/app.
+ * nginx logs forwarded to STDOUT/STDERR
 
 <a name="enterprise"></a>
 ### Switching to Phusion Passenger Enterprise

--- a/image/Dockerfile.base
+++ b/image/Dockerfile.base
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.2
-FROM phusion/baseimage:noble-1.0.2
+FROM phusion/baseimage:resolute-1.0.7
 MAINTAINER Phusion <info@phusion.nl>
 
 ADD . /pd_build

--- a/image/enable_repos.sh
+++ b/image/enable_repos.sh
@@ -5,13 +5,15 @@ source /pd_build/buildconfig
 header "Preparing APT repositories"
 
 ## Phusion Passenger
-run apt-key adv --keyserver keyserver.ubuntu.com --recv-keys D870AB033FB45BD1
+run apt-get update
+run apt-get install -y dirmngr gnupg apt-transport-https ca-certificates curl
+run curl https://oss-binaries.phusionpassenger.com/auto-software-signing-gpg-key-2025.txt | gpg --dearmor | tee /etc/apt/trusted.gpg.d/phusion.gpg >/dev/null
 if [[ "$PASSENGER_ENTERPRISE" ]]; then
-	echo "+ Enabling Passenger Enterprise APT repo"
-	echo deb https://download:$PASSENGER_ENTERPRISE_DOWNLOAD_TOKEN@www.phusionpassenger.com/enterprise_apt $(lsb_release -cs) main > /etc/apt/sources.list.d/passenger.list
+    echo "+ Enabling Passenger Enterprise APT repo"
+    echo "deb [signed-by=/etc/apt/trusted.gpg.d/phusion.gpg]" https://download:$PASSENGER_ENTERPRISE_DOWNLOAD_TOKEN@www.phusionpassenger.com/enterprise_apt $(lsb_release -cs) main > /etc/apt/sources.list.d/passenger.list
 else
-	echo "+ Enabling Passenger APT repo"
-	echo deb https://oss-binaries.phusionpassenger.com/apt/passenger $(lsb_release -cs) main > /etc/apt/sources.list.d/passenger.list
+    echo "+ Enabling Passenger APT repo"
+    echo deb "[signed-by=/etc/apt/trusted.gpg.d/phusion.gpg]" https://oss-binaries.phusionpassenger.com/apt/passenger $(lsb_release -cs) main > /etc/apt/sources.list.d/passenger.list
 fi
 
 run apt-get update

--- a/image/nginx-passenger.sh
+++ b/image/nginx-passenger.sh
@@ -45,8 +45,10 @@ run mkdir /etc/service/nginx
 run cp /pd_build/runit/nginx /etc/service/nginx/run
 run touch /etc/service/nginx/down
 
+## Install nginx-log-forwarder service, disabled by default
 run mkdir /etc/service/nginx-log-forwarder
 run cp /pd_build/runit/nginx-log-forwarder /etc/service/nginx-log-forwarder/run
+run touch /etc/service/nginx-log-forwarder/down
 
 ## Use SIGQUIT instead of SIGTERM to shutdown nginx
 run mkdir -p /etc/service/nginx/control/
@@ -56,7 +58,9 @@ run mkdir -p /var/run/passenger-instreg
 
 run sed -i 's|invoke-rc.d nginx rotate|sv 1 nginx|' /etc/logrotate.d/nginx
 run sed -i -e '/sv 1 nginx.*/a\' -e '		passenger-config reopen-logs >/dev/null 2>&1' /etc/logrotate.d/nginx
-run rm -f /var/log/nginx/error.log
+run rm -f /var/log/nginx/error.log /var/log/nginx/access.log
+run ln -sf /dev/stdout /var/log/nginx/access.log
+run ln -sf /dev/stderr /var/log/nginx/error.log
 
 ## Precompile Ruby extensions.
 if [[ -e /usr/bin/ruby4.0 ]]; then

--- a/image/prepare.sh
+++ b/image/prepare.sh
@@ -20,4 +20,4 @@ run chown app:app /home/app/.ssh
 run chmod 755 /home/app
 
 ## Create a /usr/bin/python for safety
-ln -s /usr/bin/python3.12 /usr/bin/python
+ln -s /usr/bin/python3.14 /usr/bin/python

--- a/image/python.sh
+++ b/image/python.sh
@@ -2,14 +2,14 @@
 set -e
 source /pd_build/buildconfig
 
-VERSION=${1:-3.12}
+VERSION=${1:-3.14}
 
 header "Installing Python ${VERSION}...."
 
 ## Install Python.
 rm -f /usr/bin/python
-if [[ ${VERSION} == "3.12" ]]; then
-	# baseimage already has 3.12, so just install dev support
+if [[ ${VERSION} == "3.14" ]]; then
+	# baseimage already has 3.14, so just install dev support
 	minimal_apt_get_install python3-venv python3-dev
 else
 	# otherwise install the deadsnakes PPA and install from there

--- a/image/redis.sh
+++ b/image/redis.sh
@@ -7,6 +7,7 @@ header "Installing Redis..."
 ## Install Redis.
 run apt-get update
 run apt-get install -y redis-server libhiredis-dev
+run sed -i "s|^logfile.*|logfile \"\"|" /etc/redis/redis.conf
 run mkdir /etc/service/redis
 run cp /pd_build/runit/redis /etc/service/redis/run
 run cp /pd_build/config/redis.conf /etc/redis/redis.conf

--- a/image/runit/nginx
+++ b/image/runit/nginx
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-# We ensure nginx-log-forwarder is running first so it catches the first log-lines
-sv restart /etc/service/nginx-log-forwarder
+# We ensure nginx-log-forwarder is running first so it catches the first log-lines (not used by default)
+# sv restart /etc/service/nginx-log-forwarder
 echo "*** Running /usr/sbin/nginx"
 exec /usr/sbin/nginx

--- a/image/utilities.sh
+++ b/image/utilities.sh
@@ -8,8 +8,6 @@ run minimal_apt_get_install build-essential
 run minimal_apt_get_install git
 ## JRuby94 at least requires netbase, and other client stuff must.
 run minimal_apt_get_install netbase
-## utilities needed to add apt ppas
-run minimal_apt_get_install curl gnupg ca-certificates
 ## almost everyone needs file, and it sort of randomly gets pulled in during
 ## the build process anyway
 run minimal_apt_get_install file

--- a/image/utilities.sh
+++ b/image/utilities.sh
@@ -11,3 +11,5 @@ run minimal_apt_get_install netbase
 ## almost everyone needs file, and it sort of randomly gets pulled in during
 ## the build process anyway
 run minimal_apt_get_install file
+# install packages needed for ruby builds
+run minimal_apt_get_install gawk autoconf automake bison libffi-dev libgdbm-dev libsqlite3-dev libtool libyaml-dev pkg-config sqlite3 zlib1g-dev libgmp-dev libreadline-dev libssl-dev


### PR DESCRIPTION
* Updates baseimage to one based on Ubuntu 26.04 (Resolute Raccoon)
* Changes default log output for Nginx (and Redis) to container stdout
* bumped suggested next release to 3.2.0 to reflect major update

- I tested build_all (only on amd64) and verified that the correct versions are installed in each
- I built and tested 4 full applications locally on these images (2 Ruby, 2 Python)

Further review and testing suggested. (edit: specifically not able to test Passenger Enterprise installation or anything related).